### PR TITLE
Handle status codes in remote IR provider.

### DIFF
--- a/conjureplugin/irprovider.go
+++ b/conjureplugin/irprovider.go
@@ -70,6 +70,9 @@ func (p *urlIRProvider) IRBytes() ([]byte, error) {
 		return nil, errors.WithStack(err)
 	}
 	defer cleanup()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("expected response status 200 when fetching IR from remote source %s, but got %d", p.irURL, resp.StatusCode)
+	}
 	return ioutil.ReadAll(resp.Body)
 }
 


### PR DESCRIPTION
Previously, we would return the response body's bytes regardless of status code (404, for example). We'd then just treat this response body as IR, and the resulting error message was very misleading:
```
panic: unknown error code string ""
```
with a stacktrace suggesting invalid IR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/22)
<!-- Reviewable:end -->
