### PR TITLE
publish to .conjure.json instead of ir.json

### DIFF
--- a/changelog/@unreleased/pr-60.v2.yml
+++ b/changelog/@unreleased/pr-60.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fixes the publish location of the Conjure IR to use the ".conjure.json" suffix (rather than ".ir.json").
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/60

--- a/conjureplugin/publish.go
+++ b/conjureplugin/publish.go
@@ -62,7 +62,7 @@ func Publish(params ConjureProjectParams, projectDir string, flagVals map[distgo
 	for i, param := range paramsToPublish {
 		key := paramsToPublishKeys[i]
 		currDir := path.Join(tmpDir, fmt.Sprintf("conjure-%s", key))
-		irFileName := fmt.Sprintf("%s-%s.ir.json", key, version)
+		irFileName := fmt.Sprintf("%s-%s.conjure.json", key, version)
 		keyAsDistID := distgo.DistID(key)
 		if err := os.Mkdir(currDir, 0755); err != nil {
 			return errors.WithStack(err)

--- a/conjureplugin/publish_test.go
+++ b/conjureplugin/publish_test.go
@@ -83,7 +83,7 @@ projects:
 	lines := strings.Split(outputBuf.String(), "\n")
 	assert.Equal(t, 3, len(lines), "Expected output to have 3 lines:\n%s", outputBuf.String())
 
-	wantRegexp := regexp.QuoteMeta("[DRY RUN]") + " Uploading .*?" + regexp.QuoteMeta(".ir.json") + " to " + regexp.QuoteMeta("http://artifactory.domain.com/artifactory/repo/com/palantir/foo/project-1/") + ".*?" + regexp.QuoteMeta("/project-1-") + ".*?" + regexp.QuoteMeta(".ir.json")
+	wantRegexp := regexp.QuoteMeta("[DRY RUN]") + " Uploading .*?" + regexp.QuoteMeta(".conjure.json") + " to " + regexp.QuoteMeta("http://artifactory.domain.com/artifactory/repo/com/palantir/foo/project-1/") + ".*?" + regexp.QuoteMeta("/project-1-") + ".*?" + regexp.QuoteMeta(".conjure.json")
 	assert.Regexp(t, wantRegexp, lines[0])
 
 	wantRegexp = regexp.QuoteMeta("[DRY RUN]") + " Uploading to " + regexp.QuoteMeta("http://artifactory.domain.com/artifactory/repo/com/palantir/foo/") + ".*?" + regexp.QuoteMeta(".pom")

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -258,7 +258,7 @@ projects:
 	lines := strings.Split(outputBuf.String(), "\n")
 	assert.Equal(t, 3, len(lines), "Expected output to have 3 lines:\n%s", outputBuf.String())
 
-	wantRegexp := regexp.QuoteMeta("[DRY RUN]") + " Uploading .*?" + regexp.QuoteMeta(".ir.json") + " to " + regexp.QuoteMeta(ts.URL+"/artifactory/test-repo/com/palantir/test-group/project-1/") + ".*?" + regexp.QuoteMeta("/project-1-") + ".*?" + regexp.QuoteMeta(".ir.json")
+	wantRegexp := regexp.QuoteMeta("[DRY RUN]") + " Uploading .*?" + regexp.QuoteMeta(".conjure.json") + " to " + regexp.QuoteMeta(ts.URL+"/artifactory/test-repo/com/palantir/test-group/project-1/") + ".*?" + regexp.QuoteMeta("/project-1-") + ".*?" + regexp.QuoteMeta(".conjure.json")
 	assert.Regexp(t, wantRegexp, lines[0])
 
 	wantRegexp = regexp.QuoteMeta("[DRY RUN]") + " Uploading to " + regexp.QuoteMeta(ts.URL+"/artifactory/test-repo/com/palantir/test-group/") + ".*?" + regexp.QuoteMeta(".pom")


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The publish location expected by gradle-conjure is at a file called *.conjure.json. However, we publish to *.ir.json.

## After this PR
==COMMIT_MSG==
Fixes the publish location of the conjure IR.
==COMMIT_MSG==

## Possible downsides?
Users who successfully consume *.ir.json must change to the new *.conjure.json

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/60)
<!-- Reviewable:end -->
