### PR TITLE
Fix: update CircleCI to build using Go 1.14.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ owner-repo: &owner-repo
 excutor: &executor
   executor:
     name: go/darwin-linux-no-cgo
-    version: 1.14-java-11-t41
+    version: 1.14.4-java-11-t52
     <<: *owner-repo
 
 version: 2.1


### PR DESCRIPTION
## Before this PR
Latest available version of v4 of the plugin was built using Go 1.14, which produces binaries that have known issues with certain kernels.

## After this PR
==COMMIT_MSG==
Update CircleCI configuration to build using Go 1.14.4.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/79)
<!-- Reviewable:end -->
