### PR TITLE
Make cli bundler more robust to unpacking failure

### DIFF
--- a/changelog/@unreleased/pr-85.v2.yml
+++ b/changelog/@unreleased/pr-85.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Make cli bundler more robust to unpacking failure
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/85

--- a/ir-gen-cli-bundler/conjureircli/run.go
+++ b/ir-gen-cli-bundler/conjureircli/run.go
@@ -83,31 +83,31 @@ func Run(inPath, outPath string) error {
 	return nil
 }
 
-func cliUnpackDir() string {
-	return path.Join(os.TempDir(), "_conjureircli")
-}
+// cliUnpackDir is the directory into which the tarball is unpacked
+var cliUnpackDir = path.Join(os.TempDir(), "_conjureircli")
 
-func cliArchiveDir() string {
-	return path.Join(cliUnpackDir(), fmt.Sprintf("conjure-%v", conjureircli_internal.Version))
-}
+// cliArchiveDir is the top-level directory of the unpacked archive
+var cliArchiveDir = path.Join(cliUnpackDir, fmt.Sprintf("conjure-%v", conjureircli_internal.Version))
 
+// cliCmdPath is the path to the conjure compiler executable
 func cliCmdPath() (string, error) {
 	switch runtime.GOOS {
 	case "darwin", "linux":
-		return path.Join(cliArchiveDir(), "bin", "conjure"), nil
+		return path.Join(cliArchiveDir, "bin", "conjure"), nil
 	default:
 		return "", errors.Errorf("OS %s not supported", runtime.GOOS)
 	}
 }
 
+// ensureCLIExists installs the conjure compiler if it does not already exist or it appears malformed.
 func ensureCLIExists(cliPath string) error {
-	if fi, err := os.Stat(cliPath); err == nil && fi.Mode().IsRegular() && fi.Size() > 0 {
+	if checkCliExists(cliPath) == nil {
 		// destination already exists
 		return nil
 	}
 
-	// destination does not exist or is malformed, remove the dest dir just in case of a previous bad install
-	if err := os.RemoveAll(cliArchiveDir()); err != nil {
+	// destination does not exist or is malformed, remove the archive dir just in case of a previous bad install
+	if err := os.RemoveAll(cliArchiveDir); err != nil {
 		return errors.Wrap(err, "failed to remove destination dir before unpacking cli archive")
 	}
 
@@ -116,14 +116,28 @@ func ensureCLIExists(cliPath string) error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-	if err := archiver.TarGz.Read(bytes.NewReader(tgzBytes), cliUnpackDir()); err != nil {
+	if err := archiver.TarGz.Read(bytes.NewReader(tgzBytes), cliUnpackDir); err != nil {
 		return errors.WithStack(err)
 	}
 
 	// check that we can now find the cli
-	if _, err := os.Stat(cliPath); err != nil {
+	if err := checkCliExists(cliPath); err != nil {
 		return errors.Wrap(err, "failed to stat cli file after unpacking; please comment on godel-conjure-plugin#84 and retry")
 	}
 
+	return nil
+}
+
+// checkCliExists returns an error if the cliPath is not a regular file with nonzero size.
+func checkCliExists(cliPath string) error {
+	fi, err := os.Stat(cliPath)
+	switch {
+	case err != nil:
+		return err
+	case fi.Size() == 0:
+		return errors.New("file was empty")
+	case !fi.Mode().IsRegular():
+		return fmt.Errorf("file mode %s was unexpected", fi.Mode().String())
+	}
 	return nil
 }

--- a/ir-gen-cli-bundler/conjureircli/run.go
+++ b/ir-gen-cli-bundler/conjureircli/run.go
@@ -122,7 +122,6 @@ func ensureCLIExists(cliPath string) error {
 
 	// check that we can now find the cli
 	if _, err := os.Stat(cliPath); err != nil {
-		// destination already exists
 		return errors.Wrap(err, "failed to stat cli file after unpacking; please comment on godel-conjure-plugin#84 and retry")
 	}
 


### PR DESCRIPTION
## Before this PR
We've seen failures unpacking the conjure binary (fixes #84) 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Make cli bundler more robust to unpacking failure
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/85)
<!-- Reviewable:end -->
