### PR TITLE
Update conjure version to 4.14.1

### DIFF
--- a/changelog/@unreleased/pr-111.v2.yml
+++ b/changelog/@unreleased/pr-111.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Update Conjure IR generator version to 4.14.1 to include new fields like "extensions".
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/111

--- a/ir-gen-cli-bundler/conjureircli/generator/generate.go
+++ b/ir-gen-cli-bundler/conjureircli/generator/generate.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-bindata/go-bindata"
 )
 
-const conjureVersion = "4.9.0"
+const conjureVersion = "4.14.1"
 
 func main() {
 	versionFilePath := "../internal/version.go"

--- a/ir-gen-cli-bundler/conjureircli/internal/version.go
+++ b/ir-gen-cli-bundler/conjureircli/internal/version.go
@@ -2,4 +2,4 @@
 // To update this file, run the generator in conjureircli/generator.
 package conjureircli_internal
 
-const Version = "4.9.0"
+const Version = "4.14.1"

--- a/ir-gen-cli-bundler/conjureircli/run_test.go
+++ b/ir-gen-cli-bundler/conjureircli/run_test.go
@@ -54,7 +54,8 @@ types:
       } ]
     }
   } ],
-  "services" : [ ]
+  "services" : [ ],
+  "extensions" : { }
 }`,
 		},
 	} {


### PR DESCRIPTION
## Before this PR
The Conjure IR generator uses version 4.9.0, which does not include support for some new fields like "extensions".

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update Conjure IR generator version to 4.14.1 to include new fields like "extensions".
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/111)
<!-- Reviewable:end -->
