### PR TITLE
Improvement: add ability to specify Conjure extensions to conjureircli

### DIFF
--- a/changelog/@unreleased/pr-112.v2.yml
+++ b/changelog/@unreleased/pr-112.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Adds new functions to the `conjureircli` package that adds support for specifying the content of the extensions block for generated IR.
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/112

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/palantir/godel/v2 v2.25.0
 	github.com/palantir/pkg/cobracli v1.0.1
 	github.com/palantir/pkg/safehttp v1.0.1
+	github.com/palantir/pkg/safejson v1.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.4.0

--- a/ir-gen-cli-bundler/conjureircli/run_test.go
+++ b/ir-gen-cli-bundler/conjureircli/run_test.go
@@ -24,18 +24,19 @@ import (
 
 func TestYAMLtoIR(t *testing.T) {
 	for i, tc := range []struct {
-		in   string
-		want string
+		in     string
+		params []conjureircli.Param
+		want   string
 	}{
 		{
-			`
+			in: `
 types:
   definitions:
     default-package: com.palantir.conjure
     objects:
       BooleanExample: { fields: { value: boolean } }
 `,
-			`{
+			want: `{
   "version" : 1,
   "errors" : [ ],
   "types" : [ {
@@ -58,9 +59,67 @@ types:
   "extensions" : { }
 }`,
 		},
+		{
+			in: `
+types:
+  definitions:
+    default-package: com.palantir.conjure
+    objects:
+      BooleanExample: { fields: { value: boolean } }
+`,
+			params: []conjureircli.Param{
+				mustExtensionsParam(map[string]interface{}{
+					"recommended-product-dependencies": []map[string]interface{}{
+						{
+							"product-group":   "com.palantir.assetserver",
+							"product-name":    "asset-server",
+							"minimum-version": "2.78.0",
+							"maximum-version": "2.x.x",
+						},
+					},
+				}),
+			},
+			want: `{
+  "version" : 1,
+  "errors" : [ ],
+  "types" : [ {
+    "type" : "object",
+    "object" : {
+      "typeName" : {
+        "name" : "BooleanExample",
+        "package" : "com.palantir.conjure"
+      },
+      "fields" : [ {
+        "fieldName" : "value",
+        "type" : {
+          "type" : "primitive",
+          "primitive" : "BOOLEAN"
+        }
+      } ]
+    }
+  } ],
+  "services" : [ ],
+  "extensions" : {
+    "recommended-product-dependencies" : [ {
+      "maximum-version" : "2.x.x",
+      "minimum-version" : "2.78.0",
+      "product-group" : "com.palantir.assetserver",
+      "product-name" : "asset-server"
+    } ]
+  }
+}`,
+		},
 	} {
-		got, err := conjureircli.YAMLtoIR([]byte(tc.in))
+		got, err := conjureircli.YAMLtoIRWithParams([]byte(tc.in), tc.params...)
 		require.NoError(t, err, "Case %d", i)
 		assert.Equal(t, tc.want, string(got), "Case %d\nGot:\n%s", i, got)
 	}
+}
+
+func mustExtensionsParam(in map[string]interface{}) conjureircli.Param {
+	param, err := conjureircli.ExtensionsParam(in)
+	if err != nil {
+		panic(err)
+	}
+	return param
 }


### PR DESCRIPTION
## Before this PR
The updated version of the Conjure CLI supports specifying the content of the "extensions" block of the generated Conjure IR using the `--extensions` flag, but the `conjureircli` package did not support this.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Adds new functions to the `conjureircli` package that adds support for specifying the content of the extensions block for generated IR.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/112)
<!-- Reviewable:end -->
