### PR TITLE
Update conjure version to 4.15.0

### DIFF
--- a/ir-gen-cli-bundler/conjureircli/generator/generate.go
+++ b/ir-gen-cli-bundler/conjureircli/generator/generate.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-bindata/go-bindata"
 )
 
-const conjureVersion = "4.14.1"
+const conjureVersion = "4.15.0"
 
 func main() {
 	versionFilePath := "../internal/version.go"

--- a/ir-gen-cli-bundler/conjureircli/internal/version.go
+++ b/ir-gen-cli-bundler/conjureircli/internal/version.go
@@ -2,4 +2,4 @@
 // To update this file, run the generator in conjureircli/generator.
 package conjureircli_internal
 
-const Version = "4.14.1"
+const Version = "4.15.0"


### PR DESCRIPTION
## Before this PR
The Conjure IR generator uses 4.14.1, which is behind the latest release version of 4.15.0.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update Conjure IR generator version to 4.15.0
==COMMIT_MSG==

https://github.com/palantir/conjure/releases

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/119)
<!-- Reviewable:end -->
