### PR TITLE
Feature: turn on AcceptFuncs lambda visitor generation by default

### DIFF
--- a/changelog/@unreleased/pr-144.v2.yml
+++ b/changelog/@unreleased/pr-144.v2.yml
@@ -1,0 +1,11 @@
+type: feature
+feature:
+  description: |-
+    Turn on AcceptFuncs lambda visitor generation by default
+
+    This allows passing inline lambdas for each union variant instead of
+    defining a visitor struct and implementing methods for each variant.
+    This helps reduce boilerplate and improves readability for simple code
+    when interacting with unions.
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/144

--- a/conjureplugin/config/config.go
+++ b/conjureplugin/config/config.go
@@ -52,10 +52,14 @@ func (c *ConjurePluginConfig) ToParams() (conjureplugin.ConjureProjectParams, er
 		if currConfig.Publish == nil {
 			publishVal = irProvider.GeneratedFromYAML()
 		}
+		acceptFuncsFlag := true
+		if currConfig.AcceptFuncs != nil {
+			acceptFuncsFlag = *currConfig.AcceptFuncs
+		}
 		params[key] = conjureplugin.ConjureProjectParam{
 			OutputDir:   currConfig.OutputDir,
 			IRProvider:  irProvider,
-			AcceptFuncs: currConfig.AcceptFuncs,
+			AcceptFuncs: acceptFuncsFlag,
 			Server:      currConfig.Server,
 			Publish:     publishVal,
 		}

--- a/conjureplugin/config/config_test.go
+++ b/conjureplugin/config/config_test.go
@@ -234,7 +234,7 @@ projects:
 							Locator: "localhost:8080/ir.json",
 						},
 						Server:      false,
-						AcceptFuncs: true,
+						AcceptFuncs: boolPtr(true),
 					},
 				},
 			},
@@ -270,9 +270,10 @@ func TestConjurePluginConfigToParam(t *testing.T) {
 				},
 				Params: map[string]conjureplugin.ConjureProjectParam{
 					"project-1": {
-						OutputDir:  "outputDir",
-						IRProvider: conjureplugin.NewLocalYAMLIRProvider("local/yaml-dir"),
-						Publish:    true,
+						OutputDir:   "outputDir",
+						IRProvider:  conjureplugin.NewLocalYAMLIRProvider("local/yaml-dir"),
+						Publish:     true,
+						AcceptFuncs: true,
 					},
 				},
 			},
@@ -295,9 +296,10 @@ func TestConjurePluginConfigToParam(t *testing.T) {
 				},
 				Params: map[string]conjureplugin.ConjureProjectParam{
 					"project-1": {
-						OutputDir:  "outputDir",
-						IRProvider: conjureplugin.NewLocalYAMLIRProvider("input.yml"),
-						Publish:    true,
+						OutputDir:   "outputDir",
+						IRProvider:  conjureplugin.NewLocalYAMLIRProvider("input.yml"),
+						Publish:     true,
+						AcceptFuncs: true,
 					},
 				},
 			},
@@ -311,7 +313,7 @@ func TestConjurePluginConfigToParam(t *testing.T) {
 							Type:    v1.LocatorTypeAuto,
 							Locator: "input.json",
 						},
-						AcceptFuncs: true,
+						AcceptFuncs: boolPtr(true),
 					},
 				},
 			},
@@ -346,8 +348,9 @@ func TestConjurePluginConfigToParam(t *testing.T) {
 				},
 				Params: map[string]conjureplugin.ConjureProjectParam{
 					"project-1": {
-						OutputDir:  "outputDir",
-						IRProvider: conjureplugin.NewLocalFileIRProvider("input.json"),
+						OutputDir:   "outputDir",
+						IRProvider:  conjureplugin.NewLocalFileIRProvider("input.json"),
+						AcceptFuncs: true,
 					},
 				},
 			},

--- a/conjureplugin/config/internal/v1/config.go
+++ b/conjureplugin/config/internal/v1/config.go
@@ -36,7 +36,7 @@ type SingleConjureConfig struct {
 	Server bool `yaml:"server,omitempty"`
 	// AcceptFuncs indicates if we will generate lambda based visitor code.
 	// Currently this is behind a feature flag and is subject to change.
-	AcceptFuncs bool `yaml:"accept-funcs,omitempty"`
+	AcceptFuncs *bool `yaml:"accept-funcs,omitempty"`
 }
 
 type LocatorType string


### PR DESCRIPTION
This allows passing inline lambdas for each union variant instead of
defining a visitor struct and implementing methods for each variant.
This helps reduce boilerplate and improves readability for simple code
when interacting with unions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/144)
<!-- Reviewable:end -->
