### PR TITLE
Improvement: Update conjure-go to v6.15.0

### DIFF
--- a/changelog/@unreleased/pr-169.v2.yml
+++ b/changelog/@unreleased/pr-169.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Update conjure-go to v6.15.0
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/169

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
 	github.com/mholt/archiver v2.1.0+incompatible
 	github.com/nmiyake/pkg/dirs v1.1.0
-	github.com/palantir/conjure-go/v6 v6.14.0
+	github.com/palantir/conjure-go/v6 v6.15.0
 	github.com/palantir/distgo v1.31.0
 	github.com/palantir/godel/v2 v2.42.0
 	github.com/palantir/pkg/cobracli v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/palantir/conjure-go-runtime/v2 v2.23.0/go.mod h1:tDxL5svQhuafB7yHQbie
 github.com/palantir/conjure-go-runtime/v2 v2.25.0/go.mod h1:tDxL5svQhuafB7yHQbieBDsNwtRTHrQMXmlYrIkZttI=
 github.com/palantir/conjure-go/v4 v4.2.0/go.mod h1:VSVefkM94TdXRyP7wvBeURBNOFkYRJEtxPi8BeyKFi8=
 github.com/palantir/conjure-go/v5 v5.0.1/go.mod h1:qAWik7iYoJtlHwyJ/sG0FuJx1PtzrLVCUglLH1k7NrE=
-github.com/palantir/conjure-go/v6 v6.14.0 h1:BybjeiK0kuO7UAqmRIdw6kqTCac70xvVTRVCQZuw548=
-github.com/palantir/conjure-go/v6 v6.14.0/go.mod h1:rAePFCXmBwV/p6r762CqAczU4x5XbJ3K7s2ahnK2R+Q=
+github.com/palantir/conjure-go/v6 v6.15.0 h1:ECjzs0m13BkoxJI10paM6sf9EythRDIUBG5pc+8eRak=
+github.com/palantir/conjure-go/v6 v6.15.0/go.mod h1:rAePFCXmBwV/p6r762CqAczU4x5XbJ3K7s2ahnK2R+Q=
 github.com/palantir/distgo v1.2.0/go.mod h1:jOCcoLD92T/eN4VfRxczaDIWsqyy1f0yQZMFOt3cJCw=
 github.com/palantir/distgo v1.20.0/go.mod h1:Jfsd7o7+kzCY8a3xpbPabr5IMjW6zSNOKLTNa8TJH4g=
 github.com/palantir/distgo v1.31.0 h1:CLKYSCmOH3bIqYfNf3/PUMTTEbEi96K2gf7+IqRfcTU=

--- a/vendor/github.com/palantir/conjure-go/v6/conjure/aliaswriter.go
+++ b/vendor/github.com/palantir/conjure-go/v6/conjure/aliaswriter.go
@@ -113,6 +113,8 @@ func isSimpleAliasType(t types.Type) bool {
 		return isSimpleAliasType(v.Item)
 	case *types.AliasType:
 		return isSimpleAliasType(v.Item)
+	case *types.External:
+		return isSimpleAliasType(v.Fallback)
 	default:
 		return false
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -73,7 +73,7 @@ github.com/nmiyake/pkg/errorstringer
 # github.com/nwaples/rardecode v1.0.0
 ## explicit
 github.com/nwaples/rardecode
-# github.com/palantir/conjure-go/v6 v6.14.0
+# github.com/palantir/conjure-go/v6 v6.15.0
 ## explicit; go 1.16
 github.com/palantir/conjure-go/v6/conjure
 github.com/palantir/conjure-go/v6/conjure-api/conjure/spec


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Update conjure-go to v6.15.0
==COMMIT_MSG==

## Changelog
```
(conjure-go) $ git log --pretty=oneline v6.14.0..v6.15.0
5ebfe596ad926d8e619a03ea468e6d5bf8d8bb4d Autorelease 6.15.0
1eaa5b35e03c375d9dc128da61fd835118f09fbf Fix: Generate alias encoding methods based on the external fallback type (#252)
b2cd7c4a8a43bc5c45c4598f6d2ce8075be174c5 Excavator: Manage go version (#253)
```

Full diff:
https://github.com/palantir/conjure-go/compare/v6.14.0...v6.15.0

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/169)
<!-- Reviewable:end -->
