### PR TITLE
Add arm64 builds

### DIFF
--- a/changelog/@unreleased/pr-182.v2.yml
+++ b/changelog/@unreleased/pr-182.v2.yml
@@ -1,8 +1,5 @@
 type: improvement
 improvement:
-  description: |-
-    Add arm64 builds
-
-    Support m1 macs and Linux arm as well, just because.
+  description: Add arm64 builds.
   links:
   - https://github.com/palantir/godel-conjure-plugin/pull/182

--- a/changelog/@unreleased/pr-182.v2.yml
+++ b/changelog/@unreleased/pr-182.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    Add arm64 builds
+
+    Support m1 macs and Linux arm as well, just because.
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/182

--- a/godel/config/dist-plugin.yml
+++ b/godel/config/dist-plugin.yml
@@ -9,6 +9,10 @@ products:
         arch: amd64
       - os: linux
         arch: amd64
+      - os: darwin
+        arch: arm64
+      - os: linux
+        arch: arm64
       version-var: github.com/palantir/godel-conjure-plugin/cmd.Version
     dist:
       disters:
@@ -19,6 +23,10 @@ products:
               arch: amd64
             - os: linux
               arch: amd64
+            - os: darwin
+              arch: arm64
+            - os: linux
+              arch: arm64
     publish: {}
 product-defaults:
   publish:


### PR DESCRIPTION
Support m1 macs and Linux arm as well, just because.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/182)
<!-- Reviewable:end -->
