### PR TITLE
feature: Publish recommended product dependencies in Conjure IR

### DIFF
--- a/changelog/@unreleased/pr-537.v2.yml
+++ b/changelog/@unreleased/pr-537.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Publish recommended product dependencies in Conjure IR
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/537

--- a/conjureplugin/config/config.go
+++ b/conjureplugin/config/config.go
@@ -56,13 +56,20 @@ func (c *ConjurePluginConfig) ToParams() (conjureplugin.ConjureProjectParams, er
 		if currConfig.AcceptFuncs != nil {
 			acceptFuncsFlag = *currConfig.AcceptFuncs
 		}
+
+		var serviceDependencies []conjureplugin.ServiceDependency
+		for _, serviceDependency := range currConfig.ServiceDependencies {
+			serviceDependencies = append(serviceDependencies, conjureplugin.ServiceDependency(serviceDependency))
+		}
+
 		params[key] = conjureplugin.ConjureProjectParam{
-			OutputDir:   currConfig.OutputDir,
-			IRProvider:  irProvider,
-			AcceptFuncs: acceptFuncsFlag,
-			Server:      currConfig.Server,
-			CLI:         currConfig.CLI,
-			Publish:     publishVal,
+			OutputDir:           currConfig.OutputDir,
+			IRProvider:          irProvider,
+			AcceptFuncs:         acceptFuncsFlag,
+			Server:              currConfig.Server,
+			CLI:                 currConfig.CLI,
+			Publish:             publishVal,
+			ServiceDependencies: serviceDependencies,
 		}
 	}
 	return conjureplugin.ConjureProjectParams{

--- a/conjureplugin/config/internal/v1/config.go
+++ b/conjureplugin/config/internal/v1/config.go
@@ -38,7 +38,14 @@ type SingleConjureConfig struct {
 	CLI bool `yaml:"cli,omitempty"`
 	// AcceptFuncs indicates if we will generate lambda based visitor code.
 	// Currently this is behind a feature flag and is subject to change.
-	AcceptFuncs *bool `yaml:"accept-funcs,omitempty"`
+	AcceptFuncs         *bool               `yaml:"accept-funcs,omitempty"`
+	ServiceDependencies []ServiceDependency `yaml:"service-dependencies"`
+}
+
+type ServiceDependency struct {
+	ProductGroup   string `yaml:"product-group"`
+	ProductName    string `yaml:"product-name"`
+	MaximumVersion string `yaml:"maximum-version"`
 }
 
 type LocatorType string

--- a/conjureplugin/conjureplugin.go
+++ b/conjureplugin/conjureplugin.go
@@ -79,7 +79,7 @@ func Run(params ConjureProjectParams, verify bool, projectDir string, stdout io.
 }
 
 func conjureDefinitionFromParam(param ConjureProjectParam) (spec.ConjureDefinition, error) {
-	bytes, err := param.IRProvider.IRBytes()
+	bytes, err := param.IRProvider.IRBytes(nil)
 	if err != nil {
 		return spec.ConjureDefinition{}, err
 	}

--- a/conjureplugin/irprovider.go
+++ b/conjureplugin/irprovider.go
@@ -15,8 +15,9 @@
 package conjureplugin
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/palantir/godel-conjure-plugin/v6/ir-gen-cli-bundler/conjureircli"
 	"github.com/palantir/pkg/safehttp"
@@ -24,7 +25,7 @@ import (
 )
 
 type IRProvider interface {
-	IRBytes() ([]byte, error)
+	IRBytes(*conjureircli.Extensions) ([]byte, error)
 	// Generated returns true if the IR provided by this provider is generated from YAML, false otherwise.
 	GeneratedFromYAML() bool
 }
@@ -32,21 +33,19 @@ type IRProvider interface {
 var _ IRProvider = &localYAMLIRProvider{}
 
 type localYAMLIRProvider struct {
-	path   string
-	params []conjureircli.Param
+	path string
 }
 
 // NewLocalYAMLIRProvider returns an IRProvider that provides IR generated from local YAML. The provided path must be a
 // path to a Conjure YAML file or a directory that contains Conjure YAML files.
-func NewLocalYAMLIRProvider(path string, params ...conjureircli.Param) IRProvider {
+func NewLocalYAMLIRProvider(path string) IRProvider {
 	return &localYAMLIRProvider{
-		path:   path,
-		params: params,
+		path: path,
 	}
 }
 
-func (p *localYAMLIRProvider) IRBytes() ([]byte, error) {
-	return conjureircli.InputPathToIRWithParams(p.path, p.params...)
+func (p *localYAMLIRProvider) IRBytes(extensions *conjureircli.Extensions) ([]byte, error) {
+	return conjureircli.InputPathToIR(p.path, extensions)
 }
 
 func (p *localYAMLIRProvider) GeneratedFromYAML() bool {
@@ -66,7 +65,7 @@ func NewHTTPIRProvider(irURL string) IRProvider {
 	}
 }
 
-func (p *urlIRProvider) IRBytes() ([]byte, error) {
+func (p *urlIRProvider) IRBytes(_ *conjureircli.Extensions) ([]byte, error) {
 	resp, cleanup, err := safehttp.Get(http.DefaultClient, p.irURL)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -75,7 +74,7 @@ func (p *urlIRProvider) IRBytes() ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Errorf("expected response status 200 when fetching IR from remote source %s, but got %d", p.irURL, resp.StatusCode)
 	}
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func (p *urlIRProvider) GeneratedFromYAML() bool {
@@ -95,8 +94,8 @@ func NewLocalFileIRProvider(path string) IRProvider {
 	}
 }
 
-func (p *localFileIRProvider) IRBytes() ([]byte, error) {
-	return ioutil.ReadFile(p.path)
+func (p *localFileIRProvider) IRBytes(_ *conjureircli.Extensions) ([]byte, error) {
+	return os.ReadFile(p.path)
 }
 
 func (p *localFileIRProvider) GeneratedFromYAML() bool {

--- a/conjureplugin/param.go
+++ b/conjureplugin/param.go
@@ -38,5 +38,12 @@ type ConjureProjectParam struct {
 	// AcceptFuncs will optionally generate lambda based visitor code for unions specified in this project.
 	AcceptFuncs bool
 	// Publish specifies whether or not this Conjure project should be included in the "publish" operation.
-	Publish bool
+	Publish             bool
+	ServiceDependencies []ServiceDependency
+}
+
+type ServiceDependency struct {
+	ProductGroup   string
+	ProductName    string
+	MaximumVersion string
 }

--- a/conjureplugin/publish.go
+++ b/conjureplugin/publish.go
@@ -23,6 +23,7 @@ import (
 	"github.com/palantir/distgo/distgo"
 	gitversioner "github.com/palantir/distgo/projectversioner/git"
 	"github.com/palantir/distgo/publisher/artifactory"
+	"github.com/palantir/godel-conjure-plugin/v6/ir-gen-cli-bundler/conjureircli"
 	"github.com/pkg/errors"
 )
 
@@ -97,7 +98,20 @@ func Publish(params ConjureProjectParams, projectDir string, flagVals map[distgo
 			return errors.WithStack(err)
 		}
 
-		irBytes, err := param.IRProvider.IRBytes()
+		var recommendedProductDependencies []conjureircli.ProductDependency
+		for _, serviceDependency := range param.ServiceDependencies {
+			recommendedProductDependencies = append(recommendedProductDependencies, conjureircli.ProductDependency{
+				ProductGroup:   serviceDependency.ProductGroup,
+				ProductName:    serviceDependency.ProductName,
+				MaximumVersion: serviceDependency.MaximumVersion,
+				MinimumVersion: version,
+				Optional:       false,
+			})
+		}
+
+		irBytes, err := param.IRProvider.IRBytes(&conjureircli.Extensions{
+			RecommendedProductDependencies: recommendedProductDependencies,
+		})
 		if err != nil {
 			return err
 		}

--- a/ir-gen-cli-bundler/conjureircli/run.go
+++ b/ir-gen-cli-bundler/conjureircli/run.go
@@ -17,7 +17,6 @@ package conjureircli
 import (
 	_ "embed" // required for go:embed directive
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -30,39 +29,24 @@ import (
 	"github.com/pkg/errors"
 )
 
+type Extensions struct {
+	RecommendedProductDependencies []ProductDependency `json:"recommended-product-dependencies,omitempty"`
+}
+type ProductDependency struct {
+	ProductGroup   string `json:"product-group"`
+	ProductName    string `json:"product-name"`
+	MaximumVersion string `json:"maximum-version"`
+	MinimumVersion string `json:"minimum-version"`
+	Optional       bool   `json:"optional"`
+}
+
 var (
 	//go:embed internal/conjure.tgz
 	conjureCliTGZ []byte
 )
 
-func YAMLtoIR(in []byte) (rBytes []byte, rErr error) {
-	return YAMLtoIRWithParams(in)
-}
-
-func YAMLtoIRWithParams(in []byte, params ...Param) (rBytes []byte, rErr error) {
-	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create temporary directory")
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); rErr == nil && err != nil {
-			rErr = errors.Wrapf(err, "failed to remove temporary directory")
-		}
-	}()
-
-	inPath := path.Join(tmpDir, "in.yml")
-	if err := ioutil.WriteFile(inPath, in, 0644); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return InputPathToIRWithParams(inPath, params...)
-}
-
-func InputPathToIR(inPath string) (rBytes []byte, rErr error) {
-	return InputPathToIRWithParams(inPath)
-}
-
-func InputPathToIRWithParams(inPath string, params ...Param) (rBytes []byte, rErr error) {
-	tmpDir, err := ioutil.TempDir("", "")
+func InputPathToIR(inPath string, extensions *Extensions) (rBytes []byte, rErr error) {
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create temporary directory")
 	}
@@ -73,10 +57,10 @@ func InputPathToIRWithParams(inPath string, params ...Param) (rBytes []byte, rEr
 	}()
 
 	outPath := path.Join(tmpDir, "out.json")
-	if err := RunWithParams(inPath, outPath, params...); err != nil {
+	if err := Run(inPath, outPath, extensions); err != nil {
 		return nil, err
 	}
-	irBytes, err := ioutil.ReadFile(outPath)
+	irBytes, err := os.ReadFile(outPath)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -84,42 +68,7 @@ func InputPathToIRWithParams(inPath string, params ...Param) (rBytes []byte, rEr
 }
 
 // Run invokes the "compile" operation on the Conjure CLI with the provided inPath and outPath as arguments.
-func Run(inPath, outPath string) error {
-	return RunWithParams(inPath, outPath)
-}
-
-type runArgs struct {
-	extensionsContent []byte
-}
-
-type Param interface {
-	apply(*runArgs)
-}
-
-type paramFn func(*runArgs)
-
-func (fn paramFn) apply(r *runArgs) {
-	fn(r)
-}
-
-// ExtensionsParam returns a parameter that sets the extensions of the generated Conjure IR to be the JSON-marshalled
-// content of the provided map if it is non-empty. Returns a no-op parameter if the provided map is nil or empty.
-func ExtensionsParam(extensionsContent map[string]interface{}) (Param, error) {
-	if len(extensionsContent) == 0 {
-		return nil, nil
-	}
-	extensionBytes, err := safejson.Marshal(extensionsContent)
-	if err != nil {
-		return nil, err
-	}
-	return paramFn(func(r *runArgs) {
-		r.extensionsContent = extensionBytes
-	}), nil
-}
-
-// RunWithParams invokes the "compile" operation on the Conjure CLI with the provided inPath and outPath as arguments.
-// Any arguments or configuration supplied by the provided params are also applied.
-func RunWithParams(inPath, outPath string, params ...Param) error {
+func Run(inPath, outPath string, extensions *Extensions) error {
 	cliPath, err := cliCmdPath()
 	if err != nil {
 		return err
@@ -128,25 +77,19 @@ func RunWithParams(inPath, outPath string, params ...Param) error {
 		return err
 	}
 
-	// apply provided params
-	var runArgCollector runArgs
-	for _, param := range params {
-		if param == nil {
-			continue
-		}
-		param.apply(&runArgCollector)
-	}
-
 	// invoke the "compile" command
 	args := []string{"compile"}
 
-	// if extensionsContent is non-empty, add as flag
-	if len(runArgCollector.extensionsContent) > 0 {
-		args = append(args, "--extensions", string(runArgCollector.extensionsContent))
-	}
-
 	// set the inPath and outPath as final arguments
 	args = append(args, inPath, outPath)
+
+	if extensions != nil {
+		bytes, err := safejson.Marshal(*extensions)
+		if err != nil {
+			return err
+		}
+		args = append(args, "--extensions", string(bytes))
+	}
 
 	cmd := exec.Command(cliPath, args...)
 	if output, err := cmd.CombinedOutput(); err != nil {

--- a/ir-gen-cli-bundler/conjureircli/run_test.go
+++ b/ir-gen-cli-bundler/conjureircli/run_test.go
@@ -15,18 +15,21 @@
 package conjureircli_test
 
 import (
+	"os"
+	"path"
 	"testing"
 
 	"github.com/palantir/godel-conjure-plugin/v6/ir-gen-cli-bundler/conjureircli"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestYAMLtoIR(t *testing.T) {
 	for i, tc := range []struct {
-		in     string
-		params []conjureircli.Param
-		want   string
+		in         string
+		extensions *conjureircli.Extensions
+		want       string
 	}{
 		{
 			in: `
@@ -67,17 +70,16 @@ types:
     objects:
       BooleanExample: { fields: { value: boolean } }
 `,
-			params: []conjureircli.Param{
-				mustExtensionsParam(map[string]interface{}{
-					"recommended-product-dependencies": []map[string]interface{}{
-						{
-							"product-group":   "com.palantir.assetserver",
-							"product-name":    "asset-server",
-							"minimum-version": "2.78.0",
-							"maximum-version": "2.x.x",
-						},
+			extensions: &conjureircli.Extensions{
+				RecommendedProductDependencies: []conjureircli.ProductDependency{
+					{
+						ProductGroup:   "com.palantir.assetserver",
+						ProductName:    "asset-server",
+						MinimumVersion: "2.78.0",
+						MaximumVersion: "2.x.x",
+						Optional:       false,
 					},
-				}),
+				},
 			},
 			want: `{
   "version" : 1,
@@ -101,25 +103,36 @@ types:
   "services" : [ ],
   "extensions" : {
     "recommended-product-dependencies" : [ {
+      "product-group" : "com.palantir.assetserver",
+      "product-name" : "asset-server",
       "maximum-version" : "2.x.x",
       "minimum-version" : "2.78.0",
-      "product-group" : "com.palantir.assetserver",
-      "product-name" : "asset-server"
+      "optional" : false
     } ]
   }
 }`,
 		},
 	} {
-		got, err := conjureircli.YAMLtoIRWithParams([]byte(tc.in), tc.params...)
+		got, err := yamlToIRWithExtensions([]byte(tc.in), tc.extensions)
 		require.NoError(t, err, "Case %d", i)
 		assert.Equal(t, tc.want, string(got), "Case %d\nGot:\n%s", i, got)
 	}
 }
 
-func mustExtensionsParam(in map[string]interface{}) conjureircli.Param {
-	param, err := conjureircli.ExtensionsParam(in)
+func yamlToIRWithExtensions(in []byte, extensions *conjureircli.Extensions) (rBytes []byte, rErr error) {
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
-		panic(err)
+		return nil, errors.Wrapf(err, "failed to create temporary directory")
 	}
-	return param
+	defer func() {
+		if err := os.RemoveAll(tmpDir); rErr == nil && err != nil {
+			rErr = errors.Wrapf(err, "failed to remove temporary directory")
+		}
+	}()
+
+	inPath := path.Join(tmpDir, "in.yml")
+	if err := os.WriteFile(inPath, in, 0644); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return conjureircli.InputPathToIR(inPath, extensions)
 }


### PR DESCRIPTION
### Context

Previously, Go products using this `godel-conjure-plugin` could **not declare `recommended-product-dependencies`** in their published Conjure IRs. This prevented downstream consumers from inferring compatible product dependencies from the IR, leading to potential product version incompatiblities.

### What’s Changed

- **Config Schema:**  
  - Added a new `service-dependencies` field to the `conjure-plugin.yml` config.
- **IR Generation:**  
  - During publish, the plugin now injects a `recommended-product-dependencies` array into the IR’s `extensions` section, based on the config’s `service-dependencies`.
  - Each dependency in the config is mapped to a `recommended-product-dependency` in the IR, including `product-group`, `product-name`, `maximum-version`, and a computed `minimum-version` (currently the latest git tag).
- **Internal Refactors:**  
  - Simplified and unified the way IR extensions are passed through the codebase.
  - Updated tests to validate the new behavior.

### In Use

If you make the following change to `conjure-plugin.yml`:

```diff
version: 1
projects:
  notional-service-api:
    output-dir: ./internal/generated/conjure
    ir-locator: ./internal/conjure/
    server: true
+   service-dependencies:
+    - product-group: com.palantir.notional
+      product-name: notional-service
+      maximum-version: 7.x.x
```
(inspired by [`gradle-conjure`](https://github.com/palantir/gradle-conjure)s [`serviceDependency`](https://github.com/palantir/gradle-conjure#service-dependencies))

it will affect the following change in the Conjure IR:
```diff
{
  "version": 1,
  ...
- "extensions": {}
+ "extensions": {
+   "recommended-product-dependencies": [
+     {
+       "product-group": "com.palantir.notional",
+       "product-name": "notional-service",
!        // notice `"minimum-version"` is not specified in the `conjure-plugin.yml`
!        // and is instead injected by the plugin by grabbing the current git tag
+       "minimum-version": "7.13.0",
+       "maximum-version": "7.x.x",
+       "optional": false
+     }
+   ]
+ }
}
```

### Notes & Future Work

- **Current MVP:**  
  - The `minimum-version` is conservatively set to the latest git tag.
- **Planned Improvements:**  
  - Future enhancements will analyze Conjure IRs to compute a more relaxed, accurate minimum recommended version.

### Inspiration

[`gradle-conjure`](https://github.com/palantir/gradle-conjure)s [`serviceDependency`](https://github.com/palantir/gradle-conjure#service-dependencies)
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/537)
<!-- Reviewable:end -->
