### PR TITLE
feature: Add `--extensions` flag to `conjure-publish` command

### DIFF
--- a/changelog/@unreleased/pr-538.v2.yml
+++ b/changelog/@unreleased/pr-538.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add `--extensions` flag to `conjure-publish` command
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/538

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -27,13 +27,15 @@ import (
 )
 
 var (
+	dryRunFlagVal     bool
+	extensionsFlagVal string
+
 	groupIDFlagVal    string
-	urlFlagVal        string
-	usernameFlagVal   string
 	passwordFlagVal   string
 	repositoryFlagVal string
+	urlFlagVal        string
+	usernameFlagVal   string
 	mavenNoPOMFlagVal bool
-	dryRunFlagVal     bool
 )
 
 var publishCmd = &cobra.Command{
@@ -65,18 +67,20 @@ var publishCmd = &cobra.Command{
 			}
 			flagVals[currFlag.Name] = val
 		}
-		return conjureplugin.Publish(projectParams, projectDirFlag, flagVals, dryRunFlagVal, cmd.OutOrStdout())
+
+		return conjureplugin.Publish(projectParams, projectDirFlag, flagVals, dryRunFlagVal, extensionsFlagVal, cmd.OutOrStdout())
 	},
 }
 
 func init() {
 	publishCmd.Flags().BoolVar(&dryRunFlagVal, "dry-run", false, "print the operations that would be performed")
+	publishCmd.Flags().StringVar(&extensionsFlagVal, "extensions", "", "extensions to add to the IRs extensions field, if empty no extensions will be sent to the internal Conjure IR generator")
 
 	publishCmd.Flags().StringVar(&groupIDFlagVal, string(publisher.GroupIDFlag.Name), "", publisher.GroupIDFlag.Description)
+	publishCmd.Flags().StringVar(&passwordFlagVal, string(publisher.ConnectionInfoPasswordFlag.Name), "", publisher.ConnectionInfoPasswordFlag.Description)
 	publishCmd.Flags().StringVar(&repositoryFlagVal, string(artifactory.PublisherRepositoryFlag.Name), "", artifactory.PublisherRepositoryFlag.Description)
 	publishCmd.Flags().StringVar(&urlFlagVal, string(publisher.ConnectionInfoURLFlag.Name), "", publisher.ConnectionInfoURLFlag.Description)
 	publishCmd.Flags().StringVar(&usernameFlagVal, string(publisher.ConnectionInfoUsernameFlag.Name), "", publisher.ConnectionInfoUsernameFlag.Description)
-	publishCmd.Flags().StringVar(&passwordFlagVal, string(publisher.ConnectionInfoPasswordFlag.Name), "", publisher.ConnectionInfoPasswordFlag.Description)
 	publishCmd.Flags().BoolVar(&mavenNoPOMFlagVal, string(maven.NoPOMFlag.Name), false, maven.NoPOMFlag.Description)
 	rootCmd.AddCommand(publishCmd)
 }

--- a/conjureplugin/conjureplugin.go
+++ b/conjureplugin/conjureplugin.go
@@ -79,7 +79,7 @@ func Run(params ConjureProjectParams, verify bool, projectDir string, stdout io.
 }
 
 func conjureDefinitionFromParam(param ConjureProjectParam) (spec.ConjureDefinition, error) {
-	bytes, err := param.IRProvider.IRBytes()
+	bytes, err := param.IRProvider.IRBytes("")
 	if err != nil {
 		return spec.ConjureDefinition{}, err
 	}

--- a/conjureplugin/irprovider.go
+++ b/conjureplugin/irprovider.go
@@ -15,8 +15,9 @@
 package conjureplugin
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 
 	"github.com/palantir/godel-conjure-plugin/v6/ir-gen-cli-bundler/conjureircli"
 	"github.com/palantir/pkg/safehttp"
@@ -24,7 +25,7 @@ import (
 )
 
 type IRProvider interface {
-	IRBytes() ([]byte, error)
+	IRBytes(extensions string) ([]byte, error)
 	// Generated returns true if the IR provided by this provider is generated from YAML, false otherwise.
 	GeneratedFromYAML() bool
 }
@@ -32,21 +33,19 @@ type IRProvider interface {
 var _ IRProvider = &localYAMLIRProvider{}
 
 type localYAMLIRProvider struct {
-	path   string
-	params []conjureircli.Param
+	path string
 }
 
 // NewLocalYAMLIRProvider returns an IRProvider that provides IR generated from local YAML. The provided path must be a
 // path to a Conjure YAML file or a directory that contains Conjure YAML files.
-func NewLocalYAMLIRProvider(path string, params ...conjureircli.Param) IRProvider {
+func NewLocalYAMLIRProvider(path string) IRProvider {
 	return &localYAMLIRProvider{
-		path:   path,
-		params: params,
+		path: path,
 	}
 }
 
-func (p *localYAMLIRProvider) IRBytes() ([]byte, error) {
-	return conjureircli.InputPathToIRWithParams(p.path, p.params...)
+func (p *localYAMLIRProvider) IRBytes(extensions string) ([]byte, error) {
+	return conjureircli.InputPathToIR(p.path, extensions)
 }
 
 func (p *localYAMLIRProvider) GeneratedFromYAML() bool {
@@ -66,7 +65,7 @@ func NewHTTPIRProvider(irURL string) IRProvider {
 	}
 }
 
-func (p *urlIRProvider) IRBytes() ([]byte, error) {
+func (p *urlIRProvider) IRBytes(_ string) ([]byte, error) {
 	resp, cleanup, err := safehttp.Get(http.DefaultClient, p.irURL)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -75,7 +74,7 @@ func (p *urlIRProvider) IRBytes() ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.Errorf("expected response status 200 when fetching IR from remote source %s, but got %d", p.irURL, resp.StatusCode)
 	}
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func (p *urlIRProvider) GeneratedFromYAML() bool {
@@ -95,8 +94,8 @@ func NewLocalFileIRProvider(path string) IRProvider {
 	}
 }
 
-func (p *localFileIRProvider) IRBytes() ([]byte, error) {
-	return ioutil.ReadFile(p.path)
+func (p *localFileIRProvider) IRBytes(_ string) ([]byte, error) {
+	return os.ReadFile(p.path)
 }
 
 func (p *localFileIRProvider) GeneratedFromYAML() bool {

--- a/conjureplugin/publish.go
+++ b/conjureplugin/publish.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Publish(params ConjureProjectParams, projectDir string, flagVals map[distgo.PublisherFlagName]interface{}, dryRun bool, stdout io.Writer) error {
+func Publish(params ConjureProjectParams, projectDir string, flagVals map[distgo.PublisherFlagName]interface{}, dryRun bool, extensions string, stdout io.Writer) error {
 	var paramsToPublishKeys []string
 	var paramsToPublish []ConjureProjectParam
 	for i, param := range params.OrderedParams() {
@@ -97,7 +97,7 @@ func Publish(params ConjureProjectParams, projectDir string, flagVals map[distgo
 			return errors.WithStack(err)
 		}
 
-		irBytes, err := param.IRProvider.IRBytes()
+		irBytes, err := param.IRProvider.IRBytes(extensions)
 		if err != nil {
 			return err
 		}

--- a/conjureplugin/publish_test.go
+++ b/conjureplugin/publish_test.go
@@ -77,7 +77,7 @@ projects:
 		publisher.ConnectionInfoURLFlag.Name:     "http://artifactory.domain.com",
 		publisher.GroupIDFlag.Name:               "com.palantir.foo",
 		artifactory.PublisherRepositoryFlag.Name: "repo",
-	}, true, outputBuf)
+	}, true, "", outputBuf)
 	require.NoError(t, err, "failed to publish Conjure")
 
 	lines := strings.Split(outputBuf.String(), "\n")

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/palantir/godel/v2 v2.133.0
 	github.com/palantir/pkg/cobracli v1.2.0
 	github.com/palantir/pkg/safehttp v1.1.0
-	github.com/palantir/pkg/safejson v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
@@ -40,6 +39,7 @@ require (
 	github.com/palantir/pkg v1.1.0 // indirect
 	github.com/palantir/pkg/matcher v1.2.0 // indirect
 	github.com/palantir/pkg/pkgpath v1.3.0 // indirect
+	github.com/palantir/pkg/safejson v1.1.0 // indirect
 	github.com/palantir/pkg/safeyaml v1.1.0 // indirect
 	github.com/palantir/pkg/specdir v1.2.0 // indirect
 	github.com/palantir/pkg/transform v1.1.0 // indirect

--- a/ir-gen-cli-bundler/conjureircli/run.go
+++ b/ir-gen-cli-bundler/conjureircli/run.go
@@ -17,7 +17,6 @@ package conjureircli
 import (
 	_ "embed" // required for go:embed directive
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -26,7 +25,6 @@ import (
 
 	"github.com/mholt/archiver/v3"
 	"github.com/palantir/godel-conjure-plugin/v6/ir-gen-cli-bundler/conjureircli/internal"
-	"github.com/palantir/pkg/safejson"
 	"github.com/pkg/errors"
 )
 
@@ -35,34 +33,8 @@ var (
 	conjureCliTGZ []byte
 )
 
-func YAMLtoIR(in []byte) (rBytes []byte, rErr error) {
-	return YAMLtoIRWithParams(in)
-}
-
-func YAMLtoIRWithParams(in []byte, params ...Param) (rBytes []byte, rErr error) {
-	tmpDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create temporary directory")
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); rErr == nil && err != nil {
-			rErr = errors.Wrapf(err, "failed to remove temporary directory")
-		}
-	}()
-
-	inPath := path.Join(tmpDir, "in.yml")
-	if err := ioutil.WriteFile(inPath, in, 0644); err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return InputPathToIRWithParams(inPath, params...)
-}
-
-func InputPathToIR(inPath string) (rBytes []byte, rErr error) {
-	return InputPathToIRWithParams(inPath)
-}
-
-func InputPathToIRWithParams(inPath string, params ...Param) (rBytes []byte, rErr error) {
-	tmpDir, err := ioutil.TempDir("", "")
+func InputPathToIR(inPath string, extensions string) (rBytes []byte, rErr error) {
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create temporary directory")
 	}
@@ -73,10 +45,10 @@ func InputPathToIRWithParams(inPath string, params ...Param) (rBytes []byte, rEr
 	}()
 
 	outPath := path.Join(tmpDir, "out.json")
-	if err := RunWithParams(inPath, outPath, params...); err != nil {
+	if err := Run(inPath, outPath, extensions); err != nil {
 		return nil, err
 	}
-	irBytes, err := ioutil.ReadFile(outPath)
+	irBytes, err := os.ReadFile(outPath)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -84,42 +56,7 @@ func InputPathToIRWithParams(inPath string, params ...Param) (rBytes []byte, rEr
 }
 
 // Run invokes the "compile" operation on the Conjure CLI with the provided inPath and outPath as arguments.
-func Run(inPath, outPath string) error {
-	return RunWithParams(inPath, outPath)
-}
-
-type runArgs struct {
-	extensionsContent []byte
-}
-
-type Param interface {
-	apply(*runArgs)
-}
-
-type paramFn func(*runArgs)
-
-func (fn paramFn) apply(r *runArgs) {
-	fn(r)
-}
-
-// ExtensionsParam returns a parameter that sets the extensions of the generated Conjure IR to be the JSON-marshalled
-// content of the provided map if it is non-empty. Returns a no-op parameter if the provided map is nil or empty.
-func ExtensionsParam(extensionsContent map[string]interface{}) (Param, error) {
-	if len(extensionsContent) == 0 {
-		return nil, nil
-	}
-	extensionBytes, err := safejson.Marshal(extensionsContent)
-	if err != nil {
-		return nil, err
-	}
-	return paramFn(func(r *runArgs) {
-		r.extensionsContent = extensionBytes
-	}), nil
-}
-
-// RunWithParams invokes the "compile" operation on the Conjure CLI with the provided inPath and outPath as arguments.
-// Any arguments or configuration supplied by the provided params are also applied.
-func RunWithParams(inPath, outPath string, params ...Param) error {
+func Run(inPath, outPath string, extensions string) error {
 	cliPath, err := cliCmdPath()
 	if err != nil {
 		return err
@@ -128,21 +65,11 @@ func RunWithParams(inPath, outPath string, params ...Param) error {
 		return err
 	}
 
-	// apply provided params
-	var runArgCollector runArgs
-	for _, param := range params {
-		if param == nil {
-			continue
-		}
-		param.apply(&runArgCollector)
-	}
-
 	// invoke the "compile" command
 	args := []string{"compile"}
 
-	// if extensionsContent is non-empty, add as flag
-	if len(runArgCollector.extensionsContent) > 0 {
-		args = append(args, "--extensions", string(runArgCollector.extensionsContent))
+	if extensions != "" {
+		args = append(args, "--extensions", extensions)
 	}
 
 	// set the inPath and outPath as final arguments


### PR DESCRIPTION
### Summary
This PR adds support for passing extensions directly to the conjure CLI via a new `--extensions` flag in the `conjure-publish` command. This enables users to inject custom metadata into the generated Conjure IR's extensions field.

### Background
The conjure CLI already supports an [`--extensions` flag](https://github.com/palantir/conjure/blob/9a0a3a7855a726160a45c890cf62df2128f7af13/conjure/src/main/java/com/palantir/conjure/cli/ConjureCli.java#L154-L156) that allows injecting custom metadata into the [extensions field](https://github.com/palantir/conjure/blob/master/docs/spec/intermediate_representation.md#extensions) of generated Conjure IRs. However, `godel-conjure-plugin` had no way to pass this information through to the underlying conjure CLI.

### Changes

#### CLI Interface
The `conjure-publish` command now accepts an optional `--extensions` parameter:

```diff
./godelw conjure-publish \
	--group-id"	"${GROUP_ID}" \
	--repository	"${REPOSITORY}" \
	--url		"${URL}" \
	--username	"${USERNAME}" \
	--password	"${PASSWORD}"
+	--extensions	'{"custom-metadata": {"key": "value"}}'
```

#### Conjure IR Output Impact
When `--extensions` is provided, it is injected into the generated Conjure IR:

```diff
{
  "version": 1,
  "errors": [...],
  "types": [...],
  "services": [...],
+ "extensions": {
+   "custom-metadata": {
+     "key": "value"
+   }
+ }
}
```

#### Implementation Details
- **IRProvider Interface**: Updated `IRBytes()` method to accept an `extensions` parameter
- **CLI Integration**: Extensions are passed directly to the conjure CLI's `--extensions` flag
- **Backward Compatibility**: The `--extensions` flag is optional - existing usage continues to work unchanged

### Code Cleanup
This PR also removes unused abstraction code that was added for extension handling:
- Removed `Param` interface and related extension parameter logic
- Simplified the IR generation flow to use direct string passing
- Updated imports to use recommended standard library functions where appropriate

---

==COMMIT_MSG==
Add `--extensions` flag to `conjure-publish` command
==COMMIT_MSG==

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/538)
<!-- Reviewable:end -->
