### PR TITLE
improvement: Remove redundant `TempDir` creation

### DIFF
--- a/changelog/@unreleased/pr-541.v2.yml
+++ b/changelog/@unreleased/pr-541.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: 'improvement: remove redundant `TempDir` creation'
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/541

--- a/ir-gen-cli-bundler/conjureircli/run.go
+++ b/ir-gen-cli-bundler/conjureircli/run.go
@@ -62,21 +62,21 @@ func InputPathToIR(inPath string) (rBytes []byte, rErr error) {
 }
 
 func InputPathToIRWithParams(inPath string, params ...Param) (rBytes []byte, rErr error) {
-	tmpDir, err := ioutil.TempDir("", "")
+	file, err := os.CreateTemp("", "")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create temporary directory")
+		return nil, errors.Wrapf(err, "failed to create temporary file")
 	}
+	outPath := file.Name()
 	defer func() {
-		if err := os.RemoveAll(tmpDir); rErr == nil && err != nil {
+		if err := os.Remove(outPath); rErr == nil && err != nil {
 			rErr = errors.Wrapf(err, "failed to remove temporary directory")
 		}
 	}()
 
-	outPath := path.Join(tmpDir, "out.json")
 	if err := RunWithParams(inPath, outPath, params...); err != nil {
 		return nil, err
 	}
-	irBytes, err := ioutil.ReadFile(outPath)
+	irBytes, err := os.ReadFile(outPath)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
## Before this PR
We created a temporary file by creating a temporary directory and creating a file within it to act as a temporary file.
## After this PR
We create a temporary file with [`os.CreateTemp`](https://pkg.go.dev/os#CreateTemp) which
> If dir is the empty string, CreateTemp uses the default directory for temporary files

==COMMIT_MSG==
improvement: remove redundant `TempDir` creation
==COMMIT_MSG==

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/541)
<!-- Reviewable:end -->
