### PR TITLE
fix: pass `repo` flag to `conjure-ir-extensions-provider` assets

### DIFF
--- a/changelog/@unreleased/pr-546.v2.yml
+++ b/changelog/@unreleased/pr-546.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Pass `repo` flag to `conjure-ir-extensions-provider` assets
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/546

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -68,7 +68,7 @@ var publishCmd = &cobra.Command{
 		}
 
 		return conjureplugin.Publish(projectParams, projectDirFlag, flagVals, dryRunFlagVal, cmd.OutOrStdout(),
-			extensionsprovider.New(configFileFlag, assetsFlag, urlFlagVal, groupIDFlagVal),
+			extensionsprovider.New(configFileFlag, assetsFlag, urlFlagVal, repositoryFlagVal, groupIDFlagVal),
 		)
 	},
 }

--- a/internal/extensions-provider/provider.go
+++ b/internal/extensions-provider/provider.go
@@ -36,6 +36,7 @@ type ExtensionsProvider func(irBytes []byte, conjureProject, version string) (ma
 //   - config:      The configuration string to be passed to each asset.
 //   - assets:      A list of asset executable paths to be queried for extensions.
 //   - url:         The Conjure IR URL associated with the current project.
+//   - repo:        The Conjure IR repo associated with the current project.
 //   - groupID:     The group ID of the current project.
 //
 // Returns:

--- a/internal/extensions-provider/provider.go
+++ b/internal/extensions-provider/provider.go
@@ -48,7 +48,7 @@ type ExtensionsProvider func(irBytes []byte, conjureProject, version string) (ma
 //   - If the asset is a provider, invoke it with the relevant arguments to retrieve extension data.
 //   - Merge all extension maps from the assets into a single result.
 //   - Return the combined extensions map or an error if any asset invocation or JSON parsing fails.
-func New(configFile string, assets []string, url, groupID string) ExtensionsProvider {
+func New(configFile string, assets []string, url, repo, groupID string) ExtensionsProvider {
 	return func(irBytes []byte, conjureProject, version string) (map[string]any, error) {
 		irFile, err := tempfilecreator.WriteBytesToTempFile(irBytes)
 		if err != nil {
@@ -80,6 +80,7 @@ func New(configFile string, assets []string, url, groupID string) ExtensionsProv
 				PluginConfigFile: &configFile,
 				CurrentIRFile:    &irFile,
 				URL:              &url,
+				Repo:             &repo,
 				GroupID:          &groupID,
 				ProjectName:      &conjureProject,
 				Version:          &version,
@@ -109,6 +110,7 @@ type extensionsAssetArgs struct {
 	PluginConfigFile *string `json:"config,omitempty"`
 	CurrentIRFile    *string `json:"current-ir-file,omitempty"`
 	URL              *string `json:"url,omitempty"`
+	Repo             *string `json:"repo,omitempty"`
 	GroupID          *string `json:"group-id,omitempty"`
 	ProjectName      *string `json:"project-name,omitempty"`
 	Version          *string `json:"version,omitempty"`

--- a/internal/extensions-provider/provider_test.go
+++ b/internal/extensions-provider/provider_test.go
@@ -62,7 +62,7 @@ exit 1
 		assets = append(assets, asset)
 	}
 
-	provider := extensionsprovider.New("", assets, "", "")
+	provider := extensionsprovider.New("", assets, "", "", "")
 
 	got, err := provider([]byte{}, "", "")
 	require.NoError(t, err)
@@ -81,7 +81,7 @@ exit 1
 		t.Errorf("maps are not equal:\ngot: %v\nwant:%v", got, want)
 	}
 
-	empty, err := extensionsprovider.New("", nil, "", "")([]byte{}, "", "")
+	empty, err := extensionsprovider.New("", nil, "", "", "")([]byte{}, "", "")
 	assert.NoError(t, err)
 	assert.Empty(t, empty)
 }


### PR DESCRIPTION
- wire through `repo` flag to `conjure-ir-extensions-provider` asset
  - mistakenly left out of https://github.com/palantir/godel-conjure-plugin/pull/543
- enhance README.md with better language, examples, etc. for assets

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/546)
<!-- Reviewable:end -->
