### PR TITLE
feature: add dedicated field for configuring assets of type `conjure-ir-extensions-provider`

### DIFF
--- a/changelog/@unreleased/pr-548.v2.yml
+++ b/changelog/@unreleased/pr-548.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: 'feature: add dedicated field for configuring assets of type `conjure-ir-extensions-provider`'
+  links:
+  - https://github.com/palantir/godel-conjure-plugin/pull/548

--- a/conjureplugin/config/config_test.go
+++ b/conjureplugin/config/config_test.go
@@ -241,6 +241,42 @@ projects:
 				},
 			},
 		},
+		{
+			`
+projects:
+ project:
+   output-dir: outputDir
+   ir-locator:
+     type: remote
+     locator: localhost:8080/ir.json
+   accept-funcs: true
+   extensions:
+     foo: bar
+     baz:
+       - 1
+       - 2
+     blah:
+       key: value
+`,
+			config.ConjurePluginConfig{
+				ProjectConfigs: map[string]v1.SingleConjureConfig{
+					"project": {
+						OutputDir: "outputDir",
+						IRLocator: v1.IRLocatorConfig{
+							Type:    v1.LocatorTypeRemote,
+							Locator: "localhost:8080/ir.json",
+						},
+						Server:      false,
+						AcceptFuncs: boolPtr(true),
+						Extensions: map[string]any{
+							"foo":  "bar",
+							"baz":  []any{1, 2},
+							"blah": map[any]any{"key": "value"},
+						},
+					},
+				},
+			},
+		},
 	} {
 		var got config.ConjurePluginConfig
 		err := yaml.Unmarshal([]byte(tc.in), &got)

--- a/conjureplugin/config/internal/v1/config.go
+++ b/conjureplugin/config/internal/v1/config.go
@@ -39,7 +39,7 @@ type SingleConjureConfig struct {
 	// AcceptFuncs indicates if we will generate lambda based visitor code.
 	// Currently this is behind a feature flag and is subject to change.
 	AcceptFuncs *bool `yaml:"accept-funcs,omitempty"`
-	// Metadata for consumption by assets of type `conjure-ir-extensions-provider`.
+	// Extensions contain metadata for consumption by assets of type `conjure-ir-extensions-provider`.
 	Extensions map[string]any `yaml:"extensions,omitempty"`
 }
 

--- a/conjureplugin/config/internal/v1/config.go
+++ b/conjureplugin/config/internal/v1/config.go
@@ -39,7 +39,7 @@ type SingleConjureConfig struct {
 	// AcceptFuncs indicates if we will generate lambda based visitor code.
 	// Currently this is behind a feature flag and is subject to change.
 	AcceptFuncs *bool `yaml:"accept-funcs,omitempty"`
-	// Metadata for consumption by assets.
+	// Metadata for consumption by assets of type `conjure-ir-extensions-provider`.
 	Extensions map[string]any `yaml:"extensions,omitempty"`
 }
 

--- a/conjureplugin/config/internal/v1/config.go
+++ b/conjureplugin/config/internal/v1/config.go
@@ -39,6 +39,8 @@ type SingleConjureConfig struct {
 	// AcceptFuncs indicates if we will generate lambda based visitor code.
 	// Currently this is behind a feature flag and is subject to change.
 	AcceptFuncs *bool `yaml:"accept-funcs,omitempty"`
+	// Metadata for consumption by assets.
+	Extensions map[string]any `yaml:"extensions,omitempty"`
 }
 
 type LocatorType string


### PR DESCRIPTION
In https://github.com/palantir/godel-conjure-plugin/pull/543 we added the ability for `assets` of type `conjure-ir-extensions-provider` to inject `extensions` metadata into _published_ Conjure IR.

This PR creates a dedicated configuration field (`extensions`) in `conjure-plugin.yml` for to be consumed by `assets` of type `conjure-ir-extensions-provider`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/548)
<!-- Reviewable:end -->
