### PR TITLE
Upgrade conjure-go: generate safelogging tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/nmiyake/pkg/dirs v1.1.0
-	github.com/palantir/conjure-go/v6 v6.69.0
+	github.com/palantir/conjure-go/v6 v6.70.0
 	github.com/palantir/distgo v1.85.0
 	github.com/palantir/godel/v2 v2.134.0
 	github.com/palantir/pkg/cobracli v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/nmiyake/pkg/gofiles v1.2.0 h1:L0LWMfnHyMxiLP2Cuqno163/4zK73FscEsNd7sH
 github.com/nmiyake/pkg/gofiles v1.2.0/go.mod h1:aPXiVvXPwxNanRNuFIRVPYn6eTC4qxjDZni6VNNlzMY=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
-github.com/palantir/conjure-go/v6 v6.69.0 h1:IApCqq2WQWEChh87tvEyYdSYyBb09Fa1mJ/sT34j73c=
-github.com/palantir/conjure-go/v6 v6.69.0/go.mod h1:XyD/+XS2MlCOXa3WEzFiANLpT6bRHyUVMMO6QSeVazM=
+github.com/palantir/conjure-go/v6 v6.70.0 h1:KBMsyb9XLVn5XX6kp6rCArGDXlVeB3PdXiI3eecrFlM=
+github.com/palantir/conjure-go/v6 v6.70.0/go.mod h1:hOSR6Aku6E8AYaD7jpxVWCRdVCiUd6exzvHbaZ/T6oQ=
 github.com/palantir/distgo v1.85.0 h1:W6gHMsU7WRDs9BvKFgrm6laWkSmgjSeOyeCRc4foHxc=
 github.com/palantir/distgo v1.85.0/go.mod h1:wmF0ywu5hjpxq6lp6Ig+3o3TZyFP8QVDk1rbIP9+xJU=
 github.com/palantir/distgo/pkg/git v1.0.0 h1:bryRJ9ZdJapz5tGzd/snv6U66tLxyb1b4PbPya/aqD4=

--- a/vendor/github.com/palantir/conjure-go/v6/conjure/conjure.go
+++ b/vendor/github.com/palantir/conjure-go/v6/conjure/conjure.go
@@ -82,8 +82,9 @@ func GenerateOutputFiles(conjureDefinition spec.ConjureDefinition, cfg OutputCon
 		}
 		if len(pkg.Objects) > 0 {
 			objectFile := newJenFile(pkg, def, errorRegistryImportPath)
+			safetyCache := make(map[types.Type]spec.LogSafety)
 			for _, object := range pkg.Objects {
-				writeObjectType(objectFile.Group, object)
+				writeObjectType(objectFile.Group, object, safetyCache)
 			}
 			files = append(files, newGoFile(filepath.Join(pkg.OutputDir, "structs.conjure.go"), objectFile))
 		}

--- a/vendor/github.com/palantir/conjure-go/v6/conjure/errorwriter.go
+++ b/vendor/github.com/palantir/conjure-go/v6/conjure/errorwriter.go
@@ -59,7 +59,8 @@ func writeErrorType(file *jen.Group, def *types.ErrorDefinition) {
 func astErrorInternalStructType(file *jen.Group, def *types.ErrorDefinition) {
 	allArgs := append(append([]*types.Field{}, def.SafeArgs...), def.UnsafeArgs...)
 	// Use object generator to create a struct implementing JSON encoding for the error.
-	writeObjectType(file, &types.ObjectType{Name: transforms.Private(def.Name), Fields: allArgs})
+	safetyCache := make(map[types.Type]spec.LogSafety)
+	writeObjectType(file, &types.ObjectType{Name: transforms.Private(def.Name), Fields: allArgs}, safetyCache)
 }
 
 // Declare New and Wrap constructors

--- a/vendor/github.com/palantir/conjure-go/v6/conjure/objectwriter.go
+++ b/vendor/github.com/palantir/conjure-go/v6/conjure/objectwriter.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/dave/jennifer/jen"
+	"github.com/palantir/conjure-go/v6/conjure-api/conjure/spec"
 	"github.com/palantir/conjure-go/v6/conjure/snip"
 	"github.com/palantir/conjure-go/v6/conjure/transforms"
 	"github.com/palantir/conjure-go/v6/conjure/types"
@@ -28,10 +29,32 @@ const (
 	dataVarName     = "data"
 )
 
-func writeObjectType(file *jen.Group, objectDef *types.ObjectType) {
+// logSafetyToAnnotation converts a LogSafety value to its corresponding safelogging annotation string
+func logSafetyToAnnotation(safety spec.LogSafety_Value) string {
+	switch safety {
+	case spec.LogSafety_SAFE:
+		return "@Safe"
+	case spec.LogSafety_UNSAFE:
+		return "@Unsafe"
+	case spec.LogSafety_DO_NOT_LOG:
+		return "@DoNotLog"
+	default:
+		panic("unhandled LogSafety value: " + safety)
+	}
+}
+
+func writeObjectType(file *jen.Group, objectDef *types.ObjectType, safetyCache map[types.Type]spec.LogSafety) {
 	// Declare struct type with fields
 	containsCollection := false // If contains collection, we need JSON methods to initialize empty values.
-	file.Add(objectDef.Docs.CommentLine()).Type().Id(objectDef.Name).StructFunc(func(structDecl *jen.Group) {
+
+	// Compute the overall safety of the struct and add comment-based annotation
+	overallSafety := computeObjectSafety(objectDef, safetyCache)
+	var safetyComment jen.Code = jen.Null()
+	if !overallSafety.IsUnknown() {
+		safetyComment = jen.Comment("safelogging:" + logSafetyToAnnotation(overallSafety.Value()))
+	}
+
+	structFunc := func(structDecl *jen.Group) {
 		for _, fieldDef := range objectDef.Fields {
 			jsonTag := fieldDef.Name
 			if _, isOptional := fieldDef.Type.(*types.Optional); isOptional {
@@ -45,12 +68,25 @@ func writeObjectType(file *jen.Group, objectDef *types.ObjectType) {
 				// double quotes instead.
 				fieldTags["conjure-docs"] = strings.Replace(strings.TrimSpace(string(fieldDef.Docs)), "`", `"`, -1)
 			}
+
+			// Add safety struct tag based on field's safety annotation or type safety (with recursive computation)
+			fieldSafety := getSafetyFromField(fieldDef, safetyCache)
+			if !fieldSafety.IsUnknown() {
+				fieldTags["safelogging"] = logSafetyToAnnotation(fieldSafety.Value())
+			}
 			if fieldDef.Type.Make() != nil {
 				containsCollection = true
 			}
 			structDecl.Add(fieldDef.Docs.CommentLineWithDeprecation(fieldDef.Deprecated)).Id(transforms.ExportedFieldName(fieldDef.Name)).Add(fieldDef.Type.Code()).Tag(fieldTags)
 		}
-	})
+	}
+
+	// If there are docs, add them without the trailing line since the safety comment will alreaady add the trailing line
+	if objectDef.Docs != "" {
+		file.Comment(string(objectDef.Docs))
+	}
+	file.Add(safetyComment)
+	file.Type().Id(objectDef.Name).StructFunc(structFunc)
 
 	// If there are no collections, we can defer to the default json behavior
 	// Otherwise we need to override MarshalJSON and UnmarshalJSON
@@ -92,4 +128,86 @@ func writeStructMarshalInitDecls(methodBody *jen.Group, fields []*types.Field, r
 			)
 		}
 	}
+}
+
+func getSafetyFromType(fieldType types.Type, safetyCache map[types.Type]spec.LogSafety) spec.LogSafety {
+	if safetyCache == nil {
+		safetyCache = make(map[types.Type]spec.LogSafety)
+	}
+
+	// Check cache first
+	if cached, exists := safetyCache[fieldType]; exists {
+		return cached
+	}
+
+	// Insert placeholder to detect cycles - use UNKNOWN as safe default
+	safetyCache[fieldType] = spec.New_LogSafety(spec.LogSafety_UNKNOWN)
+
+	// First check if the field type itself has safety annotations
+	fieldSafety := fieldType.Safety()
+	if !fieldSafety.IsUnknown() {
+		// Update cache with real result
+		safetyCache[fieldType] = fieldSafety
+		return fieldSafety
+	}
+
+	// If it's an ObjectType, recursively compute safety from its fields
+	if objectType, ok := fieldType.(*types.ObjectType); ok {
+		result := computeObjectSafety(objectType, safetyCache)
+		// Update cache with computed result
+		safetyCache[fieldType] = result
+		return result
+	}
+
+	// For other types without explicit safety, return unknown so no tags are added
+	// Cache already contains UNKNOWN, so just return it
+	return spec.New_LogSafety(spec.LogSafety_UNKNOWN)
+}
+
+// getSafetyFromField returns the safety of a field, considering both field-level and type-level safety annotations
+func getSafetyFromField(field *types.Field, safetyCache map[types.Type]spec.LogSafety) spec.LogSafety {
+	// First check if the field has an explicit safety annotation
+	if field.Safety != nil {
+		return *field.Safety
+	}
+	// Fall back to type-based safety
+	return getSafetyFromType(field.Type, safetyCache)
+}
+
+func computeObjectSafety(object *types.ObjectType, typeSafetyCache map[types.Type]spec.LogSafety) spec.LogSafety {
+	// Empty struct has no information to determine safety, so it should be unknown
+	if len(object.Fields) == 0 {
+		return spec.New_LogSafety(spec.LogSafety_UNKNOWN)
+	}
+
+	// Default to SAFE, then find the most restrictive level
+	// Hierarchy: safe -> unannotated -> unsafe -> do-not-log
+	overallSafety := spec.New_LogSafety(spec.LogSafety_SAFE)
+
+	for _, fieldDef := range object.Fields {
+		fieldSafety := getSafetyFromField(fieldDef, typeSafetyCache)
+
+		if fieldSafety.IsUnknown() {
+			// Field for which safety cannot be determined "contaminates" the struct - it becomes unannotated
+			// unless we already found something more restrictive
+			if overallSafety.Value() == spec.LogSafety_SAFE {
+				overallSafety = spec.New_LogSafety(spec.LogSafety_UNKNOWN)
+			}
+		} else {
+			// Specific safety value determined for field
+			switch fieldSafety.Value() {
+			case spec.LogSafety_DO_NOT_LOG:
+				return fieldSafety // Most restrictive, return immediately
+			case spec.LogSafety_UNSAFE:
+				if overallSafety.Value() == spec.LogSafety_SAFE || overallSafety.IsUnknown() {
+					overallSafety = fieldSafety
+				}
+			case spec.LogSafety_SAFE:
+				// SAFE is least restrictive, only set if we haven't found anything else
+				// (overallSafety is already SAFE by default)
+			}
+		}
+	}
+
+	return overallSafety
 }

--- a/vendor/github.com/palantir/conjure-go/v6/conjure/types/conjure_definition.go
+++ b/vendor/github.com/palantir/conjure-go/v6/conjure/types/conjure_definition.go
@@ -19,7 +19,6 @@ import (
 	"path"
 	"regexp"
 	"strings"
-	"sync"
 	"unicode"
 
 	"github.com/dave/jennifer/jen"
@@ -394,14 +393,12 @@ func (t *namedTypes) markComplete(pkg, name string) {
 func newFields(names *namedTypes, structDefs []spec.FieldDefinition, enumDefs []spec.EnumValueDefinition) []*Field {
 	var fields []*Field
 	for _, value := range structDefs {
-		if value.Safety != nil {
-			logSafetyWarning()
-		}
 		fields = append(fields, &Field{
 			Docs:       Docs(transforms.Documentation(value.Docs)),
 			Deprecated: Docs(transforms.Documentation(value.Deprecated)),
 			Name:       string(value.FieldName),
 			Type:       names.GetBySpec(value.Type),
+			Safety:     value.Safety,
 		})
 	}
 	for _, value := range enumDefs {
@@ -532,12 +529,4 @@ func sanitizePackageName(importPath string) string {
 	}
 
 	return alias
-}
-
-var logSafetyWarningOnce sync.Once
-
-func logSafetyWarning() {
-	logSafetyWarningOnce.Do(func() {
-		fmt.Println("Warning: Object definition(s) use 'safety' fields unimplemented by conjure-go.")
-	})
 }

--- a/vendor/github.com/palantir/conjure-go/v6/conjure/types/types.go
+++ b/vendor/github.com/palantir/conjure-go/v6/conjure/types/types.go
@@ -216,6 +216,15 @@ type AliasType struct {
 	base
 }
 
+// NewAliasTypeWithSafety creates an AliasType with safety annotation
+func NewAliasTypeWithSafety(name string, item Type, safety *spec.LogSafety) *AliasType {
+	return &AliasType{
+		Name:   name,
+		Item:   item,
+		safety: safety,
+	}
+}
+
 func (t *AliasType) Code() *jen.Statement {
 	return jen.Qual(t.importPath, t.Name)
 }
@@ -366,6 +375,7 @@ type Field struct {
 	Deprecated Docs
 	Name       string // JSON key or enum value
 	Type       Type   // string for enum value
+	Safety     *spec.LogSafety
 }
 
 // private utility types

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -72,7 +72,7 @@ github.com/nmiyake/pkg/errorstringer
 # github.com/nwaples/rardecode v1.1.0
 ## explicit
 github.com/nwaples/rardecode
-# github.com/palantir/conjure-go/v6 v6.69.0
+# github.com/palantir/conjure-go/v6 v6.70.0
 ## explicit; go 1.24.0
 github.com/palantir/conjure-go/v6/conjure
 github.com/palantir/conjure-go/v6/conjure-api/conjure/spec


### PR DESCRIPTION
## After this PR
[conjure-go 6.70.0](https://github.com/palantir/conjure-go/releases/tag/v6.70.0) generates safelogging tags so the linter can catch insecure loggings.
==COMMIT_MSG==
Upgrade conjure-go: generate safelogging tags
==COMMIT_MSG==

## Possible downsides?
Some projects may have build error if they are caught by the linter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/555)
<!-- Reviewable:end -->
