### PR TITLE
feature: `WARN` when `output-dir`s conflict

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -41,7 +41,7 @@ var publishCmd = &cobra.Command{
 	Use:   "publish",
 	Short: "Publish Conjure IR",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		projectParams, err := toProjectParams(configFileFlag)
+		projectParams, err := toProjectParams(configFileFlag, cmd.OutOrStdout())
 		if err != nil {
 			return err
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"log"
+	"io"
 	"os"
 
 	"github.com/palantir/godel-conjure-plugin/v6/conjureplugin"
@@ -32,15 +32,15 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run conjure-go based on project configuration",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.SetOutput(cmd.ErrOrStderr())
-		parsedConfigSet, err := toProjectParams(configFileFlag)
+		stdout := cmd.OutOrStdout()
+		parsedConfigSet, err := toProjectParams(configFileFlag, stdout)
 		if err != nil {
 			return err
 		}
 		if err := os.Chdir(projectDirFlag); err != nil {
 			return errors.Wrapf(err, "failed to set working directory")
 		}
-		return conjureplugin.Run(parsedConfigSet, verifyFlag, projectDirFlag, cmd.OutOrStdout())
+		return conjureplugin.Run(parsedConfigSet, verifyFlag, projectDirFlag, stdout)
 	},
 }
 
@@ -49,10 +49,10 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 }
 
-func toProjectParams(cfgFile string) (conjureplugin.ConjureProjectParams, error) {
+func toProjectParams(cfgFile string, stdout io.Writer) (conjureplugin.ConjureProjectParams, error) {
 	config, err := config.ReadConfigFromFile(cfgFile)
 	if err != nil {
 		return conjureplugin.ConjureProjectParams{}, err
 	}
-	return config.ToParams()
+	return config.ToParams(stdout)
 }

--- a/conjureplugin/config/config.go
+++ b/conjureplugin/config/config.go
@@ -15,8 +15,9 @@
 package config
 
 import (
+	"fmt"
+	"io"
 	"io/ioutil"
-	"log"
 	"net/url"
 	"os"
 	"sort"
@@ -34,7 +35,7 @@ func ToConjurePluginConfig(in *ConjurePluginConfig) *v1.ConjurePluginConfig {
 	return (*v1.ConjurePluginConfig)(in)
 }
 
-func (c *ConjurePluginConfig) ToParams() (conjureplugin.ConjureProjectParams, error) {
+func (c *ConjurePluginConfig) ToParams(stdout io.Writer) (conjureplugin.ConjureProjectParams, error) {
 	var keys []string
 	for k := range c.ProjectConfigs {
 		keys = append(keys, k)
@@ -72,7 +73,7 @@ func (c *ConjurePluginConfig) ToParams() (conjureplugin.ConjureProjectParams, er
 
 	for outputDir, projects := range seenDirs {
 		if len(projects) > 1 {
-			log.Printf(
+			_, _ = fmt.Fprintf(stdout,
 				"[WARNING] Duplicate outputDir detected in Conjure config (godel/config/conjure-plugin.yml): '%s'\n"+
 					"  Conflicting projects: %v\n"+
 					"  [NOTE] Multiple projects sharing the same outputDir can cause code generation to overwrite itself, which may result in 'conjure --verify' failures or other unexpected issues.\n",

--- a/conjureplugin/config/config_test.go
+++ b/conjureplugin/config/config_test.go
@@ -15,6 +15,7 @@
 package config_test
 
 import (
+	"io"
 	"testing"
 
 	"github.com/palantir/godel-conjure-plugin/v6/conjureplugin"
@@ -394,7 +395,7 @@ func TestConjurePluginConfigToParam(t *testing.T) {
 			},
 		},
 	} {
-		got, err := tc.in.ToParams()
+		got, err := tc.in.ToParams(io.Discard)
 		require.NoError(t, err, "Case %d", i)
 		assert.Equal(t, tc.want, got, "Case %d", i)
 	}

--- a/conjureplugin/publish_test.go
+++ b/conjureplugin/publish_test.go
@@ -16,6 +16,7 @@ package conjureplugin_test
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -69,7 +70,7 @@ projects:
 
 	var cfg config.ConjurePluginConfig
 	require.NoError(t, yaml.Unmarshal(pluginConfigYML, &cfg))
-	params, err := cfg.ToParams()
+	params, err := cfg.ToParams(io.Discard)
 	require.NoError(t, err, "failed to parse config set")
 
 	outputBuf := &bytes.Buffer{}


### PR DESCRIPTION
When multiple projects write generated code to the same directory, files like `extensions.conjure.json` can overwrite each other, leading to checksum mismatches and `conjure --verify` failures. This is a common misconfiguration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/609)
<!-- Reviewable:end -->
