### PR TITLE
Add assetapi package

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,39 +86,13 @@ The `--dry-run` flag can be added to print the operation that would be performed
 
 Assets
 ======
-
-`godel-conjure-plugin` supports external executables—called [assets](https://github.com/palantir/godel/wiki/Plugins#assets)—to extend its functionality through a simple, well-defined protocol.
-
-## `godel-conjure-plugin` Asset Specification
-
-An asset for `godel-conjure-plugin` is an executable that communicates via JSON through standard output and receives input through command-line arguments. The contract is as follows:
-
-1. **Asset Discovery (`_assetInfo` Probe):**
-- When invoked with a single argument `_assetInfo`, the asset must output a JSON object to stdout.
-- This JSON object **must include at least** a `type` key, whose value determines how the asset will be used by `godel-conjure-plugin`.
-- Example:
-```json
-{ "type": "conjure-ir-extensions-provider" }
-```
-> _Note: `conjure-ir-extensions-provider` is currently the only supported type._
-
-- If the asset does not output a valid JSON object with a `type` field, `godel-conjure-plugin` will fail.
-- If the asset outputs a valid JSON object where the `type` key maps to an unknown value, `godel-conjure-plugin` will ignore that asset and continure execution.
-
-2. **Asset Invocation:**
-- For its primary operation, the asset is invoked with a **single argument**: a JSON-encoded object containing contextual information (the schema depends on the asset type).
-- The asset should process this input and output a JSON object to stdout.
-- On error, the asset should return a non-zero exit code; on success, it should exit with code 0.
-
-3. **Argument Handling:**
-- The asset must **immediately fail** if invoked with anything other than one argument.
-- All information must be passed via the single JSON-encoded argument.
-
----
+`godel-conjure-plugin` supports the use of [assets](https://github.com/palantir/godel/wiki/Plugins#assets) to extend its
+functionality in defined a defined manner.
 
 ## Conjure IR Extensions Asset
-
-The only `asset type` currently supported by `godel-conjure-plugin` is `"conjure-ir-extensions-provider"`. This `asset type` allows you to add key-value pairs to the [`extensions`](https://github.com/palantir/conjure/blob/master/docs/spec/intermediate_representation.md#extensions) block of the Conjure IR **during publishing**.
+The only `asset type` currently supported by `godel-conjure-plugin` is `"conjure-ir-extensions-provider"`. This
+`asset type` allows key-value pairs to be added to the [`extensions`](https://github.com/palantir/conjure/blob/master/docs/spec/intermediate_representation.md#extensions) block of the Conjure IR **as part of the
+`publish` command (the `conjure-publish` godel task)**.
 
 ### Requirements
 

--- a/assetapi/assetapi.go
+++ b/assetapi/assetapi.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assetapi
+
+type AssetType string
+
+const (
+// Declare new asset types here
+)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,7 +15,7 @@
 package cmd
 
 import (
-	"github.com/palantir/godel-conjure-plugin/v6/internal/assetapi"
+	"github.com/palantir/godel-conjure-plugin/v6/internal/assetloader"
 	"github.com/palantir/godel/v2/framework/pluginapi"
 	"github.com/palantir/pkg/cobracli"
 	"github.com/spf13/cobra"
@@ -29,7 +29,7 @@ var (
 	configFileFlagVal string
 	assetsFlagVal     []string
 
-	loadedAssets assetapi.LoadedAssets
+	loadedAssets assetloader.LoadedAssets
 )
 
 var rootCmd = &cobra.Command{
@@ -56,7 +56,7 @@ func init() {
 	// load all assets before running any command
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		var err error
-		loadedAssets, err = assetapi.LoadAssets(assetsFlagVal)
+		loadedAssets, err = assetloader.LoadAssets(assetsFlagVal)
 		if err != nil {
 			return err
 		}

--- a/internal/assetapi/assetapi.go
+++ b/internal/assetapi/assetapi.go
@@ -15,79 +15,59 @@
 package assetapi
 
 import (
-	"fmt"
-	"os/exec"
+	"encoding/json"
 
-	"github.com/palantir/pkg/safejson"
+	"github.com/palantir/godel-conjure-plugin/v6/assetapi"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
-type AssetType string
+// Deprecated: assets of this type are deprecated and no longer recommended. The plugin will continue to support
+// them for backwards compatibility, but new projects should use an equivalent ConjureExtensionsProvider asset
+// instead.
+//
+// New asset types should be declared as exported constants in the assetapi package. However, because this asset type is
+// deprecated and does not use the assetapi interface, its declaration is in the internal assetapi package.
+const ConjureIRExtensionsProvider assetapi.AssetType = "conjure-ir-extensions-provider"
 
-const (
-	ConjureIRExtensionsProvider AssetType = "conjure-ir-extensions-provider"
-)
-
-type LoadedAssets struct {
-	ConjureIRExtensionsProviders []string
+// AllAssetsTypes returns a slice of all supported asset types.
+func AllAssetsTypes() []assetapi.AssetType {
+	return []assetapi.AssetType{
+		ConjureIRExtensionsProvider,
+	}
 }
 
-// LoadAssets takes a list of asset paths and returns a LoadedAssets struct that contains the typed assets. Returns an
-// error if any of the provided assets are not valid according to the plugin asset specification.
-func LoadAssets(assets []string) (LoadedAssets, error) {
-	loadedAssets, err := loadAssets(assets)
-	if err != nil {
-		return LoadedAssets{}, err
+// NewAssetRootCmd returns a new cobra.Command for the asset of the specified type. The provided name and description
+// are used to set the name and description for the CLI, but are not directly used as part of the asset API. The
+// returned root command has the AssetTypeCommand subcommand registered. When called, this command prints the JSON
+// string representation of the assetType, which satisfied the asset discovery API.
+//
+// Asset types should generally define an exported function of their own that returns a new *cobra.Command that is
+// derived from this one and adds the asset-specific commands that are expected.
+func NewAssetRootCmd(assetType assetapi.AssetType, name, description string) *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   name,
+		Short: description,
 	}
-	return LoadedAssets{
-		ConjureIRExtensionsProviders: loadedAssets[ConjureIRExtensionsProvider],
-	}, nil
+
+	rootCmd.AddCommand(newAssetTypeCmd(assetType))
+
+	return rootCmd
 }
 
-// loadAssets takes a list of asset paths, determines their types, and returns a map from AssetType to the list of
-// assets of that type. Returns an error if any asset cannot be executed to determine its type, or if any asset is of an
-// unsupported type.
-func loadAssets(assets []string) (map[AssetType][]string, error) {
-	assetMap := make(map[AssetType][]string)
-	for _, asset := range assets {
-		assetType, err := getAssetTypeForAsset(asset)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get asset type for asset %s", asset)
-		}
+const AssetTypeCommand = "conjure-plugin-asset-type"
 
-		if assetType != ConjureIRExtensionsProvider {
-			return nil, fmt.Errorf("unsupported asset type %s for asset %s: only asset type that is supported is %q", assetType, asset, ConjureIRExtensionsProvider)
-		}
-		assetMap[assetType] = append(assetMap[assetType], asset)
+func newAssetTypeCmd(assetType assetapi.AssetType) *cobra.Command {
+	return &cobra.Command{
+		Use:   AssetTypeCommand,
+		Short: "Prints the JSON representation of the asset type",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			jsonOutput, err := json.Marshal(assetType)
+			if err != nil {
+				return errors.Wrapf(err, "failed to marshal JSON")
+			}
+			cmd.Print(string(jsonOutput))
+			return nil
+		},
 	}
-	return assetMap, nil
-}
-
-// getAssetTypeForAsset returns the AssetType for the provided asset by executing the asset with the _assetInfo command,
-// parsing the output printed to stdout as JSON, and returning the value of the "type" field. Returns an error if the
-// asset cannot be executed, if the response cannot be parsed as JSON, or if the "type" field is missing.
-func getAssetTypeForAsset(asset string) (AssetType, error) {
-	cmd := exec.Command(asset, "_assetInfo")
-	stdout, err := cmd.Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return "", errors.Wrapf(err, "failed to execute %v\nstdout:\n%s\nstderr:\n%s", cmd.Args, string(stdout), string(exitErr.Stderr))
-		}
-		return "", fmt.Errorf("%w: failed to execute %v\nstdout:\n%s", err, cmd.Args, string(stdout))
-	}
-
-	var response assetInfoResponse
-	if err := safejson.Unmarshal(stdout, &response); err != nil {
-		return "", errors.Wrapf(err, "failed to unmarshal asset info")
-	}
-
-	if response.Type == nil {
-		return "", fmt.Errorf("invalid response from calling %v; wanted a JSON object with a `type` key; but got:\n%v", cmd.Args, string(stdout))
-	}
-
-	return AssetType(*response.Type), nil
-}
-
-type assetInfoResponse struct {
-	Type *string `json:"type"`
 }

--- a/internal/assetloader/loader.go
+++ b/internal/assetloader/loader.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assetloader
+
+import (
+	"errors"
+	"os/exec"
+	"slices"
+
+	"github.com/palantir/godel-conjure-plugin/v6/assetapi"
+	assetapiinternal "github.com/palantir/godel-conjure-plugin/v6/internal/assetapi"
+	"github.com/palantir/godel-conjure-plugin/v6/internal/cmdutils"
+	pkgerrors "github.com/pkg/errors"
+)
+
+type LoadedAssets struct {
+	ConjureIRExtensionsProviders []string
+}
+
+// LoadAssets takes a list of asset paths and returns a LoadedAssets struct that contains the typed assets. Returns an
+// error if any of the provided assets are not valid according to the plugin asset specification.
+func LoadAssets(assets []string) (LoadedAssets, error) {
+	assetTypeToAssetsMap, err := createAssetTypeToAssetsMap(assets)
+	if err != nil {
+		return LoadedAssets{}, err
+	}
+
+	return LoadedAssets{
+		ConjureIRExtensionsProviders: assetTypeToAssetsMap[assetapiinternal.ConjureIRExtensionsProvider],
+	}, nil
+}
+
+// createAssetTypeToAssetsMap takes a slice of asset paths, determines their types using the getAssetTypeForAsset
+// function, and returns a map from AssetType to the list of assets of that type. Returns an error if any asset cannot
+// be executed to determine its type, or if any asset is of an unsupported type.
+//
+// Note that this function does not perform any semantic validation of the assets: if the asset reports its type in a
+// supported manner, it is considered valid and included in the returned map. Any constraints (such as only allowing one
+// asset of a given type etc.) must be enforced by the caller.
+func createAssetTypeToAssetsMap(assets []string) (map[assetapi.AssetType][]string, error) {
+	validAssetTypes := assetapiinternal.AllAssetsTypes()
+
+	assetMap := make(map[assetapi.AssetType][]string)
+	for _, asset := range assets {
+		assetType, err := getAssetTypeForAsset(asset)
+		if err != nil {
+			return nil, pkgerrors.Wrapf(err, "failed to get asset type for asset %s", asset)
+		}
+
+		if !slices.Contains(validAssetTypes, assetType) {
+			return nil, pkgerrors.Errorf("asset %s has unrecognized type %s: supported asset types are %v", asset, assetType, validAssetTypes)
+		}
+		assetMap[assetType] = append(assetMap[assetType], asset)
+	}
+	return assetMap, nil
+}
+
+// getAssetTypeForAsset returns the AssetType for the provided asset.
+//
+// This function supports determining the asset type in 2 different ways:
+//  1. Invoking the asset with the "conjure-plugin-asset-type" command and parsing the output as a JSON string
+//  2. Invoking the asset with the "_assetInfo" command and parsing the output as JSON to get the "type" field
+//
+// The function will attempt to use both methods in order and will return the result of the first one that succeeds.
+// Returns an error if the asset cannot be executed or if neither method succeeds in determining the asset type.
+func getAssetTypeForAsset(asset string) (assetapi.AssetType, error) {
+	// if asset type can be determined using the new command, return it
+	assetType, assetTypeErr := cmdutils.GetCommandOutputAsJSON[string](exec.Command(asset, assetapiinternal.AssetTypeCommand))
+	if assetTypeErr == nil {
+		return assetapi.AssetType(assetType), nil
+	}
+
+	legacyAssetInfo, legacyAssetInfoErr := cmdutils.GetCommandOutputAsJSON[assetInfoResponse](exec.Command(asset, "_assetInfo"))
+	if legacyAssetInfoErr == nil {
+		if legacyAssetInfo.Type == nil {
+			return "", pkgerrors.Errorf("asset information response did not contain type field, which is required for legacy _assetInfo command")
+		}
+		return assetapi.AssetType(*legacyAssetInfo.Type), nil
+	}
+
+	return "", pkgerrors.Wrapf(errors.Join(assetTypeErr, legacyAssetInfoErr), "failed to determine asset type for asset %s", asset)
+}
+
+type assetInfoResponse struct {
+	Type *string `json:"type"`
+}

--- a/internal/cmdutils/cmdutils.go
+++ b/internal/cmdutils/cmdutils.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 Palantir Technologies. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdutils
+
+import (
+	"os/exec"
+
+	"github.com/palantir/pkg/safejson"
+	"github.com/pkg/errors"
+)
+
+// GetCommandOutputAsJSON runs the provided exec.Cmd, unmarshals the command's stdout as JSON into a value of type T,
+// and returns the unmarshaled value. Returns an error if an error occurs while running the command or unmarshaling the
+// output.
+func GetCommandOutputAsJSON[T any](cmd *exec.Cmd) (T, error) {
+	// needed to return zero value in case of error
+	var returnVal T
+
+	stdout, err := RunCommand(cmd)
+	if err != nil {
+		return returnVal, err
+	}
+
+	if err := safejson.Unmarshal(stdout, &returnVal); err != nil {
+		return returnVal, errors.Wrapf(err, "failed to unmarshal output as JSON")
+	}
+	return returnVal, nil
+}
+
+// RunCommand runs the provided exec.Cmd and returns the result of cmd.Output() if the returned error is nil. If the
+// returned error is non-nil, returns a wrapped error that includes the command's stdout and stderr.
+func RunCommand(cmd *exec.Cmd) ([]byte, error) {
+	stdoutOutput, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return stdoutOutput, errors.Wrapf(err, "failed to execute %v\nstdout:\n%s\nstderr:\n%s", cmd.Args, string(stdoutOutput), string(exitErr.Stderr))
+		}
+		return stdoutOutput, errors.Wrapf(err, "failed to execute %v\nstdout:\n%s", cmd.Args, string(stdoutOutput))
+	}
+	return stdoutOutput, nil
+}


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
* Adds exported "assetapi" package that allows declaring asset types
* Adds "internal/assetapi" package that provides an API and functions for creating new command-based assets
* Adds "internal/assetloader" package that provides functions for discovering and loading assets and refactors code to use it

This change is a forward-looking API-only change. Although some existing logic is refactored, it does not change any functionality, and continues to support using/loading the previously defined asset type.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/640)
<!-- Reviewable:end -->
