### PR TITLE
Refactor ToParams function to remove io.Writer parameter

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"io"
 	"os"
 
@@ -50,9 +51,19 @@ func init() {
 }
 
 func toProjectParams(cfgFile string, stdout io.Writer) (conjureplugin.ConjureProjectParams, error) {
-	config, err := config.ReadConfigFromFile(cfgFile)
+	cfg, err := config.ReadConfigFromFile(cfgFile)
 	if err != nil {
 		return conjureplugin.ConjureProjectParams{}, err
 	}
-	return config.ToParams(stdout)
+	params, warnings, err := cfg.ToParams()
+	if err != nil {
+		return conjureplugin.ConjureProjectParams{}, err
+	}
+
+	// print any warnings to stdout
+	for _, warning := range warnings {
+		_, _ = fmt.Fprintf(stdout, "[WARNING]: %s\n", warning)
+	}
+
+	return params, nil
 }

--- a/conjureplugin/config/config.go
+++ b/conjureplugin/config/config.go
@@ -15,12 +15,11 @@
 package config
 
 import (
-	"fmt"
-	"io"
-	"io/ioutil"
+	"maps"
 	"net/url"
 	"os"
-	"sort"
+	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/palantir/godel-conjure-plugin/v6/conjureplugin"
@@ -35,21 +34,31 @@ func ToConjurePluginConfig(in *ConjurePluginConfig) *v1.ConjurePluginConfig {
 	return (*v1.ConjurePluginConfig)(in)
 }
 
-func (c *ConjurePluginConfig) ToParams(stdout io.Writer) (conjureplugin.ConjureProjectParams, error) {
-	var keys []string
-	for k := range c.ProjectConfigs {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+// ToParams returns the conjureplugin.ConjureProjectParams representation of the receiver. This function performs
+// semantic validation of the configuration.
+//
+// Semantic issues with configuration are classified as either warnings or errors. Warnings are considered issues that
+// the caller may want to be alerted or warned about, but for which the configuration is still legal/valid. Errors are
+// issues that cause the configuration to be considered invalid.
+//
+// Currently, if multiple Conjure projects have the same output directory (after normalization using filepath.Clean),
+// this is considered to be warning. The returned warning is an error created using errors.Join that contains one error
+// per output path shared by multiple projects.
+func (c *ConjurePluginConfig) ToParams() (_ conjureplugin.ConjureProjectParams, warnings []error, err error) {
+	sortedKeys := slices.Sorted(maps.Keys(c.ProjectConfigs))
 
 	seenDirs := make(map[string][]string)
 	params := make(map[string]conjureplugin.ConjureProjectParam)
-	for key, currConfig := range c.ProjectConfigs {
-		seenDirs[currConfig.OutputDir] = append(seenDirs[currConfig.OutputDir], key)
+	for _, key := range sortedKeys {
+		currConfig := c.ProjectConfigs[key]
+
+		// normalize outputDir
+		outputDir := filepath.Clean(currConfig.OutputDir)
+		seenDirs[outputDir] = append(seenDirs[outputDir], key)
 
 		irProvider, err := (*IRLocatorConfig)(&currConfig.IRLocator).ToIRProvider()
 		if err != nil {
-			return conjureplugin.ConjureProjectParams{}, errors.Wrapf(err, "failed to convert configuration for %s to provider", key)
+			return conjureplugin.ConjureProjectParams{}, nil, errors.Wrapf(err, "failed to convert configuration for %s to provider", key)
 		}
 
 		groupID := c.GroupID
@@ -67,7 +76,7 @@ func (c *ConjurePluginConfig) ToParams(stdout io.Writer) (conjureplugin.ConjureP
 			acceptFuncsFlag = *currConfig.AcceptFuncs
 		}
 		params[key] = conjureplugin.ConjureProjectParam{
-			OutputDir:   currConfig.OutputDir,
+			OutputDir:   outputDir,
 			IRProvider:  irProvider,
 			AcceptFuncs: acceptFuncsFlag,
 			Server:      currConfig.Server,
@@ -77,21 +86,18 @@ func (c *ConjurePluginConfig) ToParams(stdout io.Writer) (conjureplugin.ConjureP
 		}
 	}
 
-	for outputDir, projects := range seenDirs {
-		if len(projects) > 1 {
-			_, _ = fmt.Fprintf(stdout,
-				"[WARNING] Duplicate outputDir detected in Conjure config (godel/config/conjure-plugin.yml): '%s'\n"+
-					"  Conflicting projects: %v\n"+
-					"  [NOTE] Multiple projects sharing the same outputDir can cause code generation to overwrite itself, which may result in 'conjure --verify' failures or other unexpected issues.\n",
-				outputDir, projects,
-			)
+	for _, outputDir := range slices.Sorted(maps.Keys(seenDirs)) {
+		projects := seenDirs[outputDir]
+		if len(projects) <= 1 {
+			continue
 		}
+		warnings = append(warnings, errors.Errorf("Projects %v are configured with the same outputDir %q, which may cause conflicts when generating Conjure output", projects, outputDir))
 	}
 
 	return conjureplugin.ConjureProjectParams{
-		SortedKeys: keys,
+		SortedKeys: sortedKeys,
 		Params:     params,
-	}, nil
+	}, warnings, nil
 }
 
 type SingleConjureConfig v1.SingleConjureConfig
@@ -150,7 +156,7 @@ func (cfg *IRLocatorConfig) ToIRProvider() (conjureplugin.IRProvider, error) {
 }
 
 func ReadConfigFromFile(f string) (ConjurePluginConfig, error) {
-	bytes, err := ioutil.ReadFile(f)
+	bytes, err := os.ReadFile(f)
 	if err != nil {
 		return ConjurePluginConfig{}, errors.WithStack(err)
 	}

--- a/conjureplugin/publish_test.go
+++ b/conjureplugin/publish_test.go
@@ -16,7 +16,6 @@ package conjureplugin_test
 
 import (
 	"bytes"
-	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -70,7 +69,7 @@ projects:
 
 	var cfg config.ConjurePluginConfig
 	require.NoError(t, yaml.Unmarshal(pluginConfigYML, &cfg))
-	params, err := cfg.ToParams(io.Discard)
+	params, _, err := cfg.ToParams()
 	require.NoError(t, err, "failed to parse config set")
 
 	outputBuf := &bytes.Buffer{}


### PR DESCRIPTION


## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Removes the io.Writer parameter from the ToParams function and updates it to return a set of warnings instead. Maintains the previous behavior of printing warnings to stdout if multiple projects specify the same output directory.

Other changes:
* Output path comparison is done after normalizing using filepath.Clean
* Config elements are processed in sorted order to ensure deterministic behavior
* Minor change in wording and output of warning messages
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/godel-conjure-plugin/646)
<!-- Reviewable:end -->
