### PR TITLE
Feature: Add ErrorParameterFormatJSON config option

### DIFF
--- a/conjureplugin/config/config.go
+++ b/conjureplugin/config/config.go
@@ -99,6 +99,7 @@ func (c *ConjurePluginConfig) ToParams() (_ conjureplugin.ConjureProjectParams, 
 			SkipConjureBackcompat:    currConfig.SkipBackCompat,
 			SkipDeleteGeneratedFiles: currConfig.SkipDeleteGeneratedFiles,
 			ExportErrorDecoder:       currConfig.ExportErrorDecoder,
+			ErrorParameterFormatJSON: currConfig.ErrorParameterFormatJSON,
 		})
 	}
 	var err error

--- a/conjureplugin/config/config_test.go
+++ b/conjureplugin/config/config_test.go
@@ -336,6 +336,32 @@ projects:
 				},
 			},
 		},
+		{
+			`
+projects:
+ project:
+   output-dir: outputDir
+   ir-locator:
+     type: remote
+     locator: localhost:8080/ir.json
+   error-parameter-format-json: true
+`,
+			config.ConjurePluginConfig{
+				ProjectConfigs: v2.ConjureProjectConfigs{
+					{
+						Name: "project",
+						Config: v2.SingleConjureConfig{
+							OutputDir: "outputDir",
+							IRLocator: v2.IRLocatorConfig{
+								Type:    v2.LocatorTypeRemote,
+								Locator: "localhost:8080/ir.json",
+							},
+							ErrorParameterFormatJSON: true,
+						},
+					},
+				},
+			},
+		},
 	} {
 		var got config.ConjurePluginConfig
 		err := yaml.Unmarshal([]byte(tc.in), &got)
@@ -463,19 +489,21 @@ func TestConjurePluginConfigToParam(t *testing.T) {
 								Type:    v2.LocatorTypeAuto,
 								Locator: "input.json",
 							},
-							OmitTopLevelProjectDir: true,
-							ExportErrorDecoder:     true,
+							OmitTopLevelProjectDir:   true,
+							ExportErrorDecoder:       true,
+							ErrorParameterFormatJSON: true,
 						},
 					},
 				},
 			},
 			conjureplugin.ConjureProjectParams{
 				{
-					ProjectName:        "project-1",
-					OutputDir:          "outputDir",
-					IRProvider:         conjureplugin.NewLocalFileIRProvider("input.json"),
-					AcceptFuncs:        true,
-					ExportErrorDecoder: true,
+					ProjectName:              "project-1",
+					OutputDir:                "outputDir",
+					IRProvider:               conjureplugin.NewLocalFileIRProvider("input.json"),
+					AcceptFuncs:              true,
+					ExportErrorDecoder:       true,
+					ErrorParameterFormatJSON: true,
 				},
 			},
 		},

--- a/conjureplugin/config/internal/v2/config.go
+++ b/conjureplugin/config/internal/v2/config.go
@@ -123,6 +123,10 @@ type SingleConjureConfig struct {
 	// ExportErrorDecoder generates a top-level conjureerrors package that re-exports
 	// the Decoder function from the internal conjureerrors package.
 	ExportErrorDecoder bool `yaml:"export-error-decoder,omitempty"`
+	// ErrorParameterFormatJSON, when true, causes generated service clients to send the
+	// "Accept-Conjure-Error-Parameter-Format: JSON" header on every request so that servers which
+	// support it serialize error parameters as JSON rather than the legacy string form.
+	ErrorParameterFormatJSON bool `yaml:"error-parameter-format-json,omitempty"`
 }
 
 // OutputDirConflicts detects output directory conflicts between projects.

--- a/conjureplugin/param.go
+++ b/conjureplugin/param.go
@@ -53,4 +53,8 @@ type ConjureProjectParam struct {
 	// ExportErrorDecoder generates a top-level conjureerrors package that re-exports
 	// the Decoder function from the internal conjureerrors package.
 	ExportErrorDecoder bool
+	// ErrorParameterFormatJSON, when true, causes generated service clients to send the
+	// "Accept-Conjure-Error-Parameter-Format: JSON" header so that servers which support it serialize
+	// error parameters as JSON rather than the legacy string form.
+	ErrorParameterFormatJSON bool
 }

--- a/conjureplugin/run.go
+++ b/conjureplugin/run.go
@@ -45,11 +45,12 @@ func Run(params ConjureProjectParams, verify bool, projectDir string, stdout io.
 		}
 
 		outputConf := conjure.OutputConfiguration{
-			OutputDir:            filepath.Join(projectDir, outputDir),
-			GenerateServer:       currParam.Server,
-			GenerateCLI:          currParam.CLI,
-			GenerateFuncsVisitor: currParam.AcceptFuncs,
-			ExportErrorDecoder:   currParam.ExportErrorDecoder,
+			OutputDir:                filepath.Join(projectDir, outputDir),
+			GenerateServer:           currParam.Server,
+			GenerateCLI:              currParam.CLI,
+			GenerateFuncsVisitor:     currParam.AcceptFuncs,
+			ExportErrorDecoder:       currParam.ExportErrorDecoder,
+			ErrorParameterFormatJSON: currParam.ErrorParameterFormatJSON,
 		}
 
 		conjureFilesToGenerate, err := conjure.GenerateOutputFiles(conjureDef, outputConf)


### PR DESCRIPTION
## Before this PR
No ability to configure global/per-project error parameter format.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add ErrorParameterFormatJSON config option

When `ErrorParameterFormatJSON` is set to `true`, generated service clients will send the `Accept-Conjure-Error-Parameter-Format: JSON` header on every request so that servers which support it can serialize error parameters as JSON instead of the legacy string form.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

